### PR TITLE
Fix of ctG prefactor in v2.0

### DIFF
--- a/PackageTester.nb
+++ b/PackageTester.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    580364,      14761]
-NotebookOptionsPosition[    522674,      13995]
-NotebookOutlinePosition[    523243,      14015]
-CellTagsIndexPosition[    523200,      14012]
+NotebookDataLength[    580184,      14739]
+NotebookOptionsPosition[    522481,      13973]
+NotebookOutlinePosition[    523041,      13993]
+CellTagsIndexPosition[    522998,      13990]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -54,8 +54,9 @@ Cell[BoxData["\<\"/home/alejorossia/match2fit\"\>"], "Output",
    3.963629988484973*^9, 3.964842573931196*^9, 3.96786997415761*^9, 
    3.968139875937896*^9, 3.968140631110787*^9, 3.968145258939104*^9, 
    3.9682002039233418`*^9, 3.968227781663907*^9, 3.968289310673929*^9, 
-   3.968292168353025*^9, 3.968316336530101*^9, 3.968316450142757*^9},
- CellLabel->"Out[1]=",ExpressionUUID->"aca17ebb-f6dd-4007-a11f-d8eba66ed5e8"]
+   3.968292168353025*^9, 3.968316336530101*^9, 3.968316450142757*^9, 
+   3.979956610142433*^9},
+ CellLabel->"Out[1]=",ExpressionUUID->"7067e07f-d31b-4325-bb06-4dadc608a42f"]
 }, Open  ]],
 
 Cell[CellGroupData[{
@@ -103,10 +104,11 @@ Cell[BoxData["\<\"match2fit: an interface between matching and fitting codes.\
    3.968140631233294*^9, 3.968145259083413*^9, 3.96814577565492*^9, 
    3.96814599789718*^9, 3.968146188438937*^9, 3.968146484316229*^9, 
    3.968200204053151*^9, 3.968227781786426*^9, 3.968289310850087*^9, 
-   3.9682921684762173`*^9, 3.96831633666241*^9, 3.968316450211769*^9},
+   3.9682921684762173`*^9, 3.96831633666241*^9, 3.968316450211769*^9, 
+   3.979956610406438*^9},
  CellLabel->
   "During evaluation of \
-In[2]:=",ExpressionUUID->"cde55186-c21c-4d71-adf6-66319b25d4cc"],
+In[2]:=",ExpressionUUID->"2604e2b8-af09-49c2-9306-c8a7bc1126ed"],
 
 Cell[BoxData["\<\"Version: 1.99\"\>"], "Print",
  CellChangeTimes->{
@@ -140,10 +142,11 @@ Cell[BoxData["\<\"Version: 1.99\"\>"], "Print",
    3.968140631233294*^9, 3.968145259083413*^9, 3.96814577565492*^9, 
    3.96814599789718*^9, 3.968146188438937*^9, 3.968146484316229*^9, 
    3.968200204053151*^9, 3.968227781786426*^9, 3.968289310850087*^9, 
-   3.9682921684762173`*^9, 3.96831633666241*^9, 3.968316450213423*^9},
+   3.9682921684762173`*^9, 3.96831633666241*^9, 3.968316450211769*^9, 
+   3.9799566104075117`*^9},
  CellLabel->
   "During evaluation of \
-In[2]:=",ExpressionUUID->"ddf8425d-341f-43d0-ae49-a5073752ab27"],
+In[2]:=",ExpressionUUID->"52003550-0ef8-4cea-8627-53e86ada7a92"],
 
 Cell[BoxData["\<\"Date: 01/10/2025\"\>"], "Print",
  CellChangeTimes->{
@@ -177,10 +180,11 @@ Cell[BoxData["\<\"Date: 01/10/2025\"\>"], "Print",
    3.968140631233294*^9, 3.968145259083413*^9, 3.96814577565492*^9, 
    3.96814599789718*^9, 3.968146188438937*^9, 3.968146484316229*^9, 
    3.968200204053151*^9, 3.968227781786426*^9, 3.968289310850087*^9, 
-   3.9682921684762173`*^9, 3.96831633666241*^9, 3.968316450215334*^9},
+   3.9682921684762173`*^9, 3.96831633666241*^9, 3.968316450211769*^9, 
+   3.9799566104088917`*^9},
  CellLabel->
   "During evaluation of \
-In[2]:=",ExpressionUUID->"ac7f667c-ea94-48b0-a7e0-7dc9bb12f4fe"],
+In[2]:=",ExpressionUUID->"3be8298d-cefc-4ede-84d4-c4f800e52bff"],
 
 Cell[BoxData["\<\"Author: Alejo N. Rossia\"\>"], "Print",
  CellChangeTimes->{
@@ -214,10 +218,11 @@ Cell[BoxData["\<\"Author: Alejo N. Rossia\"\>"], "Print",
    3.968140631233294*^9, 3.968145259083413*^9, 3.96814577565492*^9, 
    3.96814599789718*^9, 3.968146188438937*^9, 3.968146484316229*^9, 
    3.968200204053151*^9, 3.968227781786426*^9, 3.968289310850087*^9, 
-   3.9682921684762173`*^9, 3.96831633666241*^9, 3.968316450216549*^9},
+   3.9682921684762173`*^9, 3.96831633666241*^9, 3.968316450211769*^9, 
+   3.9799566104095917`*^9},
  CellLabel->
   "During evaluation of \
-In[2]:=",ExpressionUUID->"1c36331b-20a5-46ba-94fe-247be3643574"],
+In[2]:=",ExpressionUUID->"bf445ea2-dce5-4ab8-844e-143f9a89f497"],
 
 Cell[BoxData["\<\"Affiliations: Universit\[AGrave] degli Studi di Padova e \
 INFN Sezione di Padova.\"\>"], "Print",
@@ -252,10 +257,11 @@ INFN Sezione di Padova.\"\>"], "Print",
    3.968140631233294*^9, 3.968145259083413*^9, 3.96814577565492*^9, 
    3.96814599789718*^9, 3.968146188438937*^9, 3.968146484316229*^9, 
    3.968200204053151*^9, 3.968227781786426*^9, 3.968289310850087*^9, 
-   3.9682921684762173`*^9, 3.96831633666241*^9, 3.968316450217751*^9},
+   3.9682921684762173`*^9, 3.96831633666241*^9, 3.968316450211769*^9, 
+   3.9799566104103003`*^9},
  CellLabel->
   "During evaluation of \
-In[2]:=",ExpressionUUID->"c9414602-8680-43b6-8440-62ebb5c6742c"]
+In[2]:=",ExpressionUUID->"1123ae48-1878-47fd-96f8-6c7cbb0b8f6c"]
 }, Open  ]]
 }, Open  ]],
 
@@ -319,8 +325,8 @@ Cell[BoxData[
  RowBox[{"parametersListFromMatchingResult", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult.dat\>\""}], ",", "0"}], 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult.dat\>\""}], ",", "0"}], 
   "]"}]], "Input",
  CellChangeTimes->{3.9073940694821353`*^9},
  CellLabel->"In[6]:=",ExpressionUUID->"37c34ea8-8b1f-4414-a539-62e926caf03e"],
@@ -341,9 +347,9 @@ Cell[BoxData[
  RowBox[{"parametersListFromMatchingResult", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_T1_oneloop.dat\>\""}], ",", "0"}], 
-  "]"}]], "Input",
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_T1_oneloop.dat\>\""}], ",", 
+   "0"}], "]"}]], "Input",
  CellChangeTimes->{{3.898061731369063*^9, 3.898061736080695*^9}, {
    3.90593165321137*^9, 3.905931656844365*^9}, 3.905931786499769*^9, {
    3.905932054564663*^9, 3.9059320897888255`*^9}},
@@ -370,9 +376,9 @@ Cell[BoxData[
  RowBox[{"parametersListFromMatchingResult", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", "1"}],
-   "]"}]], "Input",
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", 
+   "1"}], "]"}]], "Input",
  CellChangeTimes->{
   3.907228289554648*^9, {3.9217290513649755`*^9, 3.9217290531079416`*^9}},
  CellLabel->"In[8]:=",ExpressionUUID->"66af303e-cb67-4d5b-9327-cda4b4801186"],
@@ -431,9 +437,9 @@ Cell[BoxData[
  RowBox[{"parametersListFromMatchingResult", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}], 
-   ",", "\"\<tree\>\""}], "]"}]], "Input",
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}\
+], ",", "\"\<tree\>\""}], "]"}]], "Input",
  CellChangeTimes->{{3.92191868224187*^9, 3.9219186869524784`*^9}},
  CellLabel->"In[10]:=",ExpressionUUID->"55aefbc4-27ec-4de2-82a6-32374989edbe"],
 
@@ -493,8 +499,8 @@ Cell[CellGroupData[{
 Cell[BoxData[
  RowBox[{"flavourSymChecker", "[", 
   RowBox[{
-   RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-   "\"\</sample_results/MatchingResult.dat\>\""}], "]"}]], "Input",
+   RowBox[{"NotebookDirectory", "[", "]"}], 
+   "<>", "\"\</sample_results/MatchingResult.dat\>\""}], "]"}]], "Input",
  CellChangeTimes->{{3.9073941744295034`*^9, 3.9073941819228563`*^9}},
  CellLabel->"In[11]:=",ExpressionUUID->"ca8531b3-54e3-41e7-957e-d1a8ccfef51c"],
 
@@ -531,8 +537,9 @@ Cell[CellGroupData[{
 Cell[BoxData[
  RowBox[{"flavourSymChecker", "[", 
   RowBox[{
-   RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-   "\"\</sample_results/MatchingResult_T2_oneloop.dat\>\""}], "]"}]], "Input",
+   RowBox[{"NotebookDirectory", "[", "]"}], 
+   "<>", "\"\</sample_results/MatchingResult_T2_oneloop.dat\>\""}], 
+  "]"}]], "Input",
  CellChangeTimes->{
   3.89936525122435*^9, {3.9059316347472506`*^9, 3.9059316382909007`*^9}, {
    3.9073925337530737`*^9, 3.907392534590139*^9}},
@@ -573,9 +580,9 @@ Cell[CellGroupData[{
 Cell[BoxData[
  RowBox[{"flavourSymChecker", "[", 
   RowBox[{
-   RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-   "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}], 
-  "]"}]], "Input",
+   RowBox[{"NotebookDirectory", "[", "]"}], 
+   "<>", "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}\
+], "]"}]], "Input",
  CellChangeTimes->{{3.8992654004105153`*^9, 3.899265408545922*^9}, {
   3.908017414325336*^9, 3.908017425843814*^9}},
  CellLabel->"In[13]:=",ExpressionUUID->"b6af6127-000d-41ab-b002-a3ad732d5646"],
@@ -659,9 +666,9 @@ Cell[BoxData[
  RowBox[{"flavourSymChecker", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}], 
-   ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}\
+], ",", 
    RowBox[{"{", 
     RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
      RowBox[{"{", 
@@ -798,9 +805,9 @@ Cell[BoxData[
  RowBox[{"flavourSymChecker", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}], 
-   ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}\
+], ",", 
    RowBox[{"{", 
     RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
      RowBox[{"{", 
@@ -915,8 +922,8 @@ Cell[CellGroupData[{
 Cell[BoxData[
  RowBox[{"flavourSolver", "[", 
   RowBox[{
-   RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-   "\"\</sample_results/MatchingResult.dat\>\""}], "]"}]], "Input",
+   RowBox[{"NotebookDirectory", "[", "]"}], 
+   "<>", "\"\</sample_results/MatchingResult.dat\>\""}], "]"}]], "Input",
  CellChangeTimes->{{3.899364934232704*^9, 3.8993649344479914`*^9}},
  CellLabel->"In[16]:=",ExpressionUUID->"318ec813-fd03-4b7c-ada8-ce339af3e4bc"],
 
@@ -989,8 +996,9 @@ Cell[CellGroupData[{
 Cell[BoxData[
  RowBox[{"flavourSolver", "[", 
   RowBox[{
-   RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-   "\"\</sample_results/MatchingResult_T2_oneloop.dat\>\""}], "]"}]], "Input",
+   RowBox[{"NotebookDirectory", "[", "]"}], 
+   "<>", "\"\</sample_results/MatchingResult_T2_oneloop.dat\>\""}], 
+  "]"}]], "Input",
  CellChangeTimes->{{3.9073928166259766`*^9, 3.9073928201854095`*^9}},
  CellLabel->"In[17]:=",ExpressionUUID->"925f3b7f-208e-4bee-a0db-7dc703aa60d9"],
 
@@ -1232,8 +1240,8 @@ Cell[BoxData[
   RowBox[{"flavourSolver", "[", 
    RowBox[{
     RowBox[{
-     RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-     "\"\</sample_results/MatchingResult.dat\>\""}], ",", 
+     RowBox[{"NotebookDirectory", "[", "]"}], 
+     "<>", "\"\</sample_results/MatchingResult.dat\>\""}], ",", 
     RowBox[{"{", 
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", "realDiagSMYukas"}], 
      "}"}]}], "]"}]}]], "Input",
@@ -1326,8 +1334,8 @@ Cell[BoxData[
  RowBox[{"flavourSymChecker", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult.dat\>\""}], ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult.dat\>\""}], ",", 
    RowBox[{"{", 
     RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
      RowBox[{"Join", "[", 
@@ -1362,9 +1370,9 @@ Cell[BoxData[
  RowBox[{"flavourSolver", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}], 
-   ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}\
+], ",", 
    RowBox[{"{", 
     RowBox[{"\"\<UVFlavourAssumption\>\"", "->", "realDiagSMYukas"}], "}"}]}],
    "]"}]], "Input",
@@ -1673,9 +1681,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult.dat\>\""}], ",", "1", ",", "0"}], 
-  "]"}]], "Input",
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult.dat\>\""}], ",", "1", ",", 
+   "0"}], "]"}]], "Input",
  CellChangeTimes->{{3.8862445470814853`*^9, 3.886244553878346*^9}, {
    3.8862445899553723`*^9, 3.8862446432755957`*^9}, {3.886246710106382*^9, 
    3.8862467645642443`*^9}, 3.8865011484601884`*^9, {3.8865012088866873`*^9, 
@@ -1704,9 +1712,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}], 
-   ",", "1", ",", "\"\<tree\>\""}], "]"}]], "Input",
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}\
+], ",", "1", ",", "\"\<tree\>\""}], "]"}]], "Input",
  CellChangeTimes->{{3.8993662477522397`*^9, 3.899366257712139*^9}, {
   3.899366294332429*^9, 3.899366295240383*^9}, {3.907318292313155*^9, 
   3.9073182957375603`*^9}},
@@ -1722,9 +1730,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", "1", 
-   ",", "0", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", 
+   "1", ",", "0", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -1773,9 +1781,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}], 
-   ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}\
+], ",", 
    RowBox[{"{", 
     RowBox[{"3.0", ",", "4.5", ",", "2.5"}], "}"}], ",", "\"\<tree\>\"", ",", 
    RowBox[{"{", 
@@ -1881,9 +1889,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}], 
-   ",", "1", ",", "\"\<tree\>\"", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}\
+], ",", "1", ",", "\"\<tree\>\"", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -1974,9 +1982,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<sample_results/MatchingResult_T2_oneloop.dat\>\""}], ",", "1", ",", 
-   "\"\<tree\>\"", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<sample_results/MatchingResult_T2_oneloop.dat\>\""}], ",", "1", 
+   ",", "\"\<tree\>\"", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -2000,9 +2008,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<sample_results/MatchingResult_T1_oneloop.dat\>\""}], ",", "10", ",", 
-   "\"\<loop\>\"", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<sample_results/MatchingResult_T1_oneloop.dat\>\""}], ",", "10",
+    ",", "\"\<loop\>\"", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -2022,7 +2030,7 @@ Cell[BoxData[
    3.9073888268055944`*^9}, {3.907394580130438*^9, 3.9073945881936784`*^9}, 
    3.920372562108819*^9},
  CellLabel->"In[28]:=",ExpressionUUID->"49a7ed0c-d7f3-47bd-8b8e-0021ba8c183b"]
-}, Closed]],
+}, Open  ]],
 
 Cell[CellGroupData[{
 
@@ -2100,9 +2108,8 @@ Cell[BoxData[
    RowBox[{
     RowBox[{"NotebookDirectory", "[", "]"}], "<>", "\"\<sample_model/\>\""}], 
    ",", "\"\<T1\>\"", ",", "\"\<tree\>\"", ",", 
-   RowBox[{
-   "\"\<QGRAFPath\>\"", "->", "\"\</home/alejorossia/qgraf-3.4.2\>\""}]}], 
-  "]"}]], "Input",
+   RowBox[{"\"\<QGRAFPath\>\"", 
+    "->", "\"\</home/alejorossia/qgraf-3.4.2\>\""}]}], "]"}]], "Input",
  CellChangeTimes->{{3.968289285328102*^9, 3.9682893069933147`*^9}, 
    3.968289357286373*^9},
  CellLabel->"In[6]:=",ExpressionUUID->"a6c8414a-b193-4a50-910f-c5ccd2b58450"],
@@ -2155,8 +2162,8 @@ Cell[BoxData[{
    RowBox[{"matcher", "[", 
     RowBox[{
      RowBox[{
-      RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-      "\"\<sample_model/\>\""}], ",", "\"\<T1\>\"", ",", "1", ",", 
+      RowBox[{"NotebookDirectory", "[", "]"}], 
+      "<>", "\"\<sample_model/\>\""}], ",", "\"\<T1\>\"", ",", "1", ",", 
      RowBox[{"\"\<QGRAFPath\>\"", "->", "globalQGRAFPath"}]}], "]"}], 
    "*)"}]}]}], "Input",
  CellChangeTimes->{{3.886583229611268*^9, 3.886583235346731*^9}, 
@@ -2209,9 +2216,9 @@ Cell[BoxData[{
    RowBox[{"modelToUVscanCard", "[", 
     RowBox[{
      RowBox[{
-      RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-      "\"\<sample_model/\>\""}], ",", "\"\<T1\>\"", ",", "1", ",", 
-     "\"\<tree\>\"", ",", 
+      RowBox[{"NotebookDirectory", "[", "]"}], 
+      "<>", "\"\<sample_model/\>\""}], ",", "\"\<T1\>\"", ",", "1", 
+     ",", "\"\<tree\>\"", ",", 
      RowBox[{"{", 
       RowBox[{
        RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -2269,9 +2276,9 @@ Cell[BoxData[{
    RowBox[{"modelToUVscanCard", "[", 
     RowBox[{
      RowBox[{
-      RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-      "\"\<sample_model/\>\""}], ",", "\"\<T1\>\"", ",", "1", ",", 
-     "\"\<loop\>\"", ",", 
+      RowBox[{"NotebookDirectory", "[", "]"}], 
+      "<>", "\"\<sample_model/\>\""}], ",", "\"\<T1\>\"", ",", "1", 
+     ",", "\"\<loop\>\"", ",", 
      RowBox[{"{", 
       RowBox[{
        RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -2394,9 +2401,8 @@ Cell[BoxData[{
               RowBox[{"i", ",", "3"}], "]"}], 
              RowBox[{"gWLf", "[", 
               RowBox[{"3", ",", "3"}], "]"}]}]}], ")"}]}]}]}], "}"}]}], ",", 
-     RowBox[{
-     "\"\<Collection\>\"", "->", "\"\<MatchingMultiparticleCollection\>\""}], 
-     ",", 
+     RowBox[{"\"\<Collection\>\"", 
+      "->", "\"\<MatchingMultiparticleCollection\>\""}], ",", 
      RowBox[{"\"\<OutputFormat\>\"", "->", "\"\<SMEFiT\>\""}]}], "}"}]}], 
   "]"}], "\[IndentingNewLine]", 
  RowBox[{
@@ -2404,9 +2410,9 @@ Cell[BoxData[{
    RowBox[{"modelToUVscanCard", "[", 
     RowBox[{
      RowBox[{
-      RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-      "\"\<sample_model/\>\""}], ",", "\"\<Q17_W1\>\"", ",", "1", ",", 
-     "\"\<Tree\>\"", ",", 
+      RowBox[{"NotebookDirectory", "[", "]"}], 
+      "<>", "\"\<sample_model/\>\""}], ",", "\"\<Q17_W1\>\"", ",", "1", 
+     ",", "\"\<Tree\>\"", ",", 
      RowBox[{"{", 
       RowBox[{
        RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -2482,9 +2488,8 @@ Cell[BoxData[{
                 RowBox[{"i", ",", "3"}], "]"}], 
                RowBox[{"gWLf", "[", 
                 RowBox[{"3", ",", "3"}], "]"}]}]}], ")"}]}]}]}], "}"}]}], ",", 
-       RowBox[{
-       "\"\<Collection\>\"", "->", 
-        "\"\<MatchingMultiparticleCollection\>\""}], ",", 
+       RowBox[{"\"\<Collection\>\"", 
+        "->", "\"\<MatchingMultiparticleCollection\>\""}], ",", 
        RowBox[{"\"\<OutputFormat\>\"", "->", "\"\<SMEFiT\>\""}], ",", 
        RowBox[{"\"\<QGRAFPath\>\"", "->", "globalQGRAFPath"}]}], "}"}]}], 
     "]"}], "*)"}]}]}], "Input",
@@ -2517,7 +2522,7 @@ in:\\n/home/alejorossia/match2fit/sample_model/Q17_W1_MM/MatchingResult.dat\"\
 In[10]:=",ExpressionUUID->"4915a712-30e9-4c21-8647-e6e04888bcf1"]
 }, Open  ]]
 }, Open  ]]
-}, Open  ]]
+}, Closed]]
 }, Open  ]],
 
 Cell[CellGroupData[{
@@ -2531,9 +2536,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y_12_32_CustoDegen.dat\>\""}],
-    ",", "4", ",", "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y_12_32_CustoDegen.dat\>\
+\""}], ",", "4", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -2570,9 +2575,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y32.dat\>\""}], ",", "4", ",",
-    "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y32.dat\>\""}], ",", 
+   "4", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -2602,9 +2607,9 @@ Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y12.dat\>\""}], ",", "4", ",",
-    "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y12.dat\>\""}], ",", 
+   "4", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -2634,9 +2639,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<sample_results/MatchingResult_T1_oneloop.dat\>\""}], ",", "1", ",", 
-   "\"\<loop\>\"", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<sample_results/MatchingResult_T1_oneloop.dat\>\""}], ",", "1", 
+   ",", "\"\<loop\>\"", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -2657,9 +2662,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}], 
-   ",", "1", ",", "\"\<tree\>\"", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_multiparticle_treelevel.dat\>\""}\
+], ",", "1", ",", "\"\<tree\>\"", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -2743,9 +2748,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", "1", 
-   ",", "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", 
+   "1", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -2771,15 +2776,15 @@ Cell[BoxData[
      RowBox[{"\"\<OutputFormat\>\"", "->", "\"\<SMEFiT\>\""}]}], "}"}]}], 
   "]"}]], "Input",
  CellChangeTimes->{{3.940412594586705*^9, 3.940412614579113*^9}},
- CellLabel->"In[39]:=",ExpressionUUID->"aacf9821-3826-41fd-9083-d7f226471680"],
+ CellLabel->"In[5]:=",ExpressionUUID->"aacf9821-3826-41fd-9083-d7f226471680"],
 
 Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", "1", 
-   ",", "0", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", 
+   "1", ",", "0", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -2811,9 +2816,9 @@ Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", "1", 
-   ",", "0", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", 
+   "1", ",", "0", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -2845,9 +2850,9 @@ Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", "1", 
-   ",", "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", 
+   "1", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -2873,15 +2878,15 @@ Cell[BoxData[
      RowBox[{"\"\<OutputFormat\>\"", "->", "\"\<Universal\>\""}]}], "}"}]}], 
   "]"}]], "Input",
  CellChangeTimes->{3.9404979364962997`*^9},
- CellLabel->"In[42]:=",ExpressionUUID->"7516f598-1283-4061-aa94-f0ab48871018"],
+ CellLabel->"In[7]:=",ExpressionUUID->"7516f598-1283-4061-aa94-f0ab48871018"],
 
 Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", "1", 
-   ",", "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", 
+   "1", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -2907,15 +2912,15 @@ Cell[BoxData[
      RowBox[{"\"\<OutputFormat\>\"", "->", "\"\<SMEFiT\>\""}]}], "}"}]}], 
   "]"}]], "Input",
  CellChangeTimes->{{3.940498132496263*^9, 3.9404981339577847`*^9}},
- CellLabel->"In[43]:=",ExpressionUUID->"83069df7-95a9-4342-89a1-53be5260159c"],
+ CellLabel->"In[8]:=",ExpressionUUID->"83069df7-95a9-4342-89a1-53be5260159c"],
 
 Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y_12_32_CustoDegen.dat\>\""}],
-    ",", "1", ",", "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y_12_32_CustoDegen.dat\>\
+\""}], ",", "1", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -2952,9 +2957,9 @@ Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y32.dat\>\""}], ",", "1", ",",
-    "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y32.dat\>\""}], ",", 
+   "1", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -2984,9 +2989,9 @@ Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y12.dat\>\""}], ",", "1", ",",
-    "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y12.dat\>\""}], ",", 
+   "1", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -3051,9 +3056,9 @@ Cell[BoxData[
          RowBox[{"lambdaT1", "[", "3", "]"}]}]}], "}"}]}], ",", 
      RowBox[{"\"\<Collection\>\"", "->", "\"\<TreeLevel\>\""}], ",", 
      RowBox[{"\"\<OutputFormat\>\"", "->", "\"\<SMEFiT\>\""}], ",", 
-     RowBox[{
-     "\"\<QGRAFPath\>\"", "->", "\"\</home/alejorossia/qgraf-3.4.2\>\""}]}], 
-    "}"}]}], "]"}]], "Code",
+     RowBox[{"\"\<QGRAFPath\>\"", 
+      "->", "\"\</home/alejorossia/qgraf-3.4.2\>\""}]}], "}"}]}], 
+  "]"}]], "Code",
  InitializationCell->False,
  CellChangeTimes->{{3.968315756241209*^9, 3.9683157832017813`*^9}, {
   3.968315834849328*^9, 3.9683159079705772`*^9}, {3.968315972346984*^9, 
@@ -3113,9 +3118,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", "8", 
-   ",", "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", 
+   "8", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -3145,15 +3150,15 @@ Cell[BoxData[
  CellChangeTimes->{{3.9427414269790487`*^9, 3.9427414703229427`*^9}, 
    3.942741578883418*^9, 3.943676861901338*^9, {3.943677278173115*^9, 
    3.94367729653864*^9}},
- CellLabel->"In[47]:=",ExpressionUUID->"4de1aa9b-a0e5-4753-b0a9-ab22cabcea43"],
+ CellLabel->"In[9]:=",ExpressionUUID->"4de1aa9b-a0e5-4753-b0a9-ab22cabcea43"],
 
 Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", "8", 
-   ",", "0", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", 
+   "8", ",", "0", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -3193,9 +3198,9 @@ Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", "1", 
-   ",", "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", 
+   "1", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -3225,15 +3230,15 @@ Cell[BoxData[
  CellChangeTimes->{{3.9427416359104233`*^9, 3.942741648092463*^9}, {
   3.9436768656939707`*^9, 3.943676866852935*^9}, {3.943677263007183*^9, 
   3.94367726390438*^9}},
- CellLabel->"In[49]:=",ExpressionUUID->"65857bb5-0a29-4899-87fd-3add76772773"],
+ CellLabel->"In[10]:=",ExpressionUUID->"65857bb5-0a29-4899-87fd-3add76772773"],
 
 Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", "1", 
-   ",", "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", 
+   "1", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -3260,15 +3265,15 @@ Cell[BoxData[
      RowBox[{"\"\<Model\>\"", "->", "\"\<Varphi\>\""}]}], "}"}]}], 
   "]"}]], "Input",
  CellChangeTimes->{3.9530038038945637`*^9},
- CellLabel->"In[50]:=",ExpressionUUID->"b173725a-ee62-324d-8a5e-0c2a591b4be3"],
+ CellLabel->"In[11]:=",ExpressionUUID->"b173725a-ee62-324d-8a5e-0c2a591b4be3"],
 
 Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", "1", 
-   ",", "0", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_Varphi_oneloop.dat\>\""}], ",", 
+   "1", ",", "0", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -3296,7 +3301,7 @@ Cell[BoxData[
   "]"}]], "Input",
  CellChangeTimes->{3.9530038205641346`*^9},
  CellLabel->"In[51]:=",ExpressionUUID->"e67a3992-5825-8546-867a-885243b2e716"]
-}, Open  ]],
+}, Closed]],
 
 Cell[CellGroupData[{
 
@@ -3336,9 +3341,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<sample_results/MatchingResult_T1_oneloop.dat\>\""}], ",", "10", ",", 
-   "\"\<loop\>\"", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<sample_results/MatchingResult_T1_oneloop.dat\>\""}], ",", "10",
+    ",", "\"\<loop\>\"", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -3359,15 +3364,15 @@ Cell[BoxData[
    3.9073242467952447`*^9, 3.907324251378916*^9}, {3.907388822603848*^9, 
    3.9073888268055944`*^9}, {3.907394580130438*^9, 3.9073945881936784`*^9}, 
    3.920372562108819*^9, {3.94274210564097*^9, 3.942742122590761*^9}},
- CellLabel->"In[52]:=",ExpressionUUID->"b4fe155e-35a7-4e9d-92ab-a6cebd055a5a"],
+ CellLabel->"In[12]:=",ExpressionUUID->"b4fe155e-35a7-4e9d-92ab-a6cebd055a5a"],
 
 Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<sample_results/MatchingResult_T1_oneloop.dat\>\""}], ",", "1", ",", 
-   "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<sample_results/MatchingResult_T1_oneloop.dat\>\""}], ",", "1", 
+   ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -3383,7 +3388,7 @@ Cell[BoxData[
      RowBox[{"\"\<OutputFormat\>\"", "->", "\"\<SMEFiT\>\""}]}], "}"}]}], 
   "]"}]], "Input",
  CellChangeTimes->{{3.9427421713091993`*^9, 3.942742195173265*^9}},
- CellLabel->"In[53]:=",ExpressionUUID->"da834576-328b-43da-a2d4-ab4e18f5e48c"]
+ CellLabel->"In[13]:=",ExpressionUUID->"da834576-328b-43da-a2d4-ab4e18f5e48c"]
 }, Open  ]],
 
 Cell[CellGroupData[{
@@ -3400,8 +3405,7 @@ ee2ca2c1b7f7"],
 Cell[TextData[{
  Cell[BoxData[
   FormBox[
-   SubscriptBox["T", "2"], TraditionalForm]],
-  FormatType->TraditionalForm,ExpressionUUID->
+   SubscriptBox["T", "2"], TraditionalForm]],ExpressionUUID->
   "88a75e0c-6f2b-4164-89f5-d33aa0ba7529"],
  " is a vector-like heavy fermion, in the irrep ",
  Cell[BoxData[
@@ -3409,8 +3413,7 @@ Cell[TextData[{
    SubscriptBox[
     RowBox[{"(", 
      RowBox[{"3", ",", "3"}], ")"}], 
-    RowBox[{"2", "/", "3"}]], TraditionalForm]],
-  FormatType->TraditionalForm,ExpressionUUID->
+    RowBox[{"2", "/", "3"}]], TraditionalForm]],ExpressionUUID->
   "b76f7b40-9984-475b-845b-b12f9b1cdb81"],
  ". First, we print some cards for UV scans and the for the mass scan.\nThe \
 cards for this model have been used in arXiv: 2309.04523, 2404.12809, \
@@ -3425,9 +3428,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<sample_results/MatchingResult_T2_oneloop.dat\>\""}], ",", "10", ",", 
-   "\"\<loop\>\"", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<sample_results/MatchingResult_T2_oneloop.dat\>\""}], ",", "10",
+    ",", "\"\<loop\>\"", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -3448,15 +3451,15 @@ Cell[BoxData[
    3.920373602986759*^9, {3.920373686839772*^9, 3.92037370628411*^9}, 
    3.920430096324792*^9, {3.920430420051421*^9, 3.920430430531496*^9}, {
    3.942742209077475*^9, 3.942742226713853*^9}, 3.942742302393119*^9},
- CellLabel->"In[54]:=",ExpressionUUID->"35fd6aea-457c-495a-9270-cfb11eee0f8c"],
+ CellLabel->"In[14]:=",ExpressionUUID->"35fd6aea-457c-495a-9270-cfb11eee0f8c"],
 
 Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<sample_results/MatchingResult_T2_oneloop.dat\>\""}], ",", "1", ",", 
-   "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<sample_results/MatchingResult_T2_oneloop.dat\>\""}], ",", "1", 
+   ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -3478,7 +3481,7 @@ Cell[BoxData[
    3.920430096324792*^9, {3.920430420051421*^9, 3.920430430531496*^9}, {
    3.942742209077475*^9, 3.942742226713853*^9}, {3.942742280733704*^9, 
    3.942742303821966*^9}},
- CellLabel->"In[55]:=",ExpressionUUID->"1489b0a4-f67f-4df4-b93b-ae76af65760e"]
+ CellLabel->"In[15]:=",ExpressionUUID->"1489b0a4-f67f-4df4-b93b-ae76af65760e"]
 }, Open  ]],
 
 Cell[CellGroupData[{
@@ -3510,9 +3513,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<sample_results/MatchingResult_Scalar_Xi_oneloop.dat\>\""}], ",", 
-   "20", ",", "\"\<loop\>\"", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<sample_results/MatchingResult_Scalar_Xi_oneloop.dat\>\""}], ",",
+    "20", ",", "\"\<loop\>\"", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -3538,9 +3541,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<sample_results/MatchingResult_Scalar_Xi_oneloop.dat\>\""}], ",", 
-   "20", ",", "\"\<tree\>\"", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<sample_results/MatchingResult_Scalar_Xi_oneloop.dat\>\""}], ",",
+    "20", ",", "\"\<tree\>\"", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -3566,9 +3569,9 @@ Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<sample_results/MatchingResult_Scalar_Xi_oneloop.dat\>\""}], ",", "1",
-    ",", "\"\<loop\>\"", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<sample_results/MatchingResult_Scalar_Xi_oneloop.dat\>\""}], ",",
+    "1", ",", "\"\<loop\>\"", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -3627,9 +3630,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<sample_results/MatchingResult_Xi_1_oneloop.dat\>\""}], ",", "20", 
-   ",", "\"\<loop\>\"", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<sample_results/MatchingResult_Xi_1_oneloop.dat\>\""}], ",", 
+   "20", ",", "\"\<loop\>\"", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -3662,9 +3665,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<sample_results/MatchingResult_Xi_1_oneloop.dat\>\""}], ",", "20", 
-   ",", "\"\<tree\>\"", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<sample_results/MatchingResult_Xi_1_oneloop.dat\>\""}], ",", 
+   "20", ",", "\"\<tree\>\"", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -3696,9 +3699,9 @@ Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<sample_results/MatchingResult_Xi_1_oneloop.dat\>\""}], ",", "1", 
-   ",", "\"\<loop\>\"", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<sample_results/MatchingResult_Xi_1_oneloop.dat\>\""}], ",", 
+   "1", ",", "\"\<loop\>\"", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "\[Rule]", 
@@ -3744,8 +3747,7 @@ Cell[TextData[{
  Cell[BoxData[
   FormBox[
    SubscriptBox["\[CapitalTheta]", 
-    RowBox[{"1", "/", "2"}]], TraditionalForm]],
-  FormatType->TraditionalForm,ExpressionUUID->
+    RowBox[{"1", "/", "2"}]], TraditionalForm]],ExpressionUUID->
   "050024a5-9d07-4338-a1bc-4fcff5550a84"],
  " is a heavy scalar EW quadruplet in the irrep ",
  Cell[BoxData[
@@ -3753,8 +3755,7 @@ Cell[TextData[{
    SubscriptBox[
     RowBox[{"(", 
      RowBox[{"1", ",", "4"}], ")"}], 
-    RowBox[{"1", "/", "2"}]], TraditionalForm]],
-  FormatType->TraditionalForm,ExpressionUUID->
+    RowBox[{"1", "/", "2"}]], TraditionalForm]],ExpressionUUID->
   "979d5c14-c0a9-4778-ba14-97cbae44865e"],
  ". First, we print some cards for UV scans and the for the mass scan.\nThe \
 UV assumptions are chosen to reproduce the results in arXiv:2209.00666\nThe \
@@ -3772,9 +3773,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y12.dat\>\""}], ",", "4", ",",
-    "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y12.dat\>\""}], ",", 
+   "4", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -3803,9 +3804,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y12.dat\>\""}], ",", "4", ",",
-    "0", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y12.dat\>\""}], ",", 
+   "4", ",", "0", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -3833,9 +3834,9 @@ Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y12.dat\>\""}], ",", "1", ",",
-    "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y12.dat\>\""}], ",", 
+   "1", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -3876,8 +3877,7 @@ Cell[TextData[{
  Cell[BoxData[
   FormBox[
    SubscriptBox["\[CapitalTheta]", 
-    RowBox[{"3", "/", "2"}]], TraditionalForm]],
-  FormatType->TraditionalForm,ExpressionUUID->
+    RowBox[{"3", "/", "2"}]], TraditionalForm]],ExpressionUUID->
   "ef7a94d8-67b3-4cfd-ae6d-a5472cc31cad"],
  " is a heavy scalar EW quadruplet in the irrep ",
  Cell[BoxData[
@@ -3885,8 +3885,7 @@ Cell[TextData[{
    SubscriptBox[
     RowBox[{"(", 
      RowBox[{"1", ",", "4"}], ")"}], 
-    RowBox[{"3", "/", "2"}]], TraditionalForm]],
-  FormatType->TraditionalForm,ExpressionUUID->
+    RowBox[{"3", "/", "2"}]], TraditionalForm]],ExpressionUUID->
   "3d75c672-a1ec-4d20-bacd-6117eb44f8fc"],
  ". First, we print some cards for UV scans and the for the mass scan.\nThe \
 UV assumptions are chosen to reproduce the results in arXiv:2209.00666\nThe \
@@ -3903,9 +3902,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y32.dat\>\""}], ",", "4", ",",
-    "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y32.dat\>\""}], ",", 
+   "4", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -3936,9 +3935,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y32.dat\>\""}], ",", "4", ",",
-    "0", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y32.dat\>\""}], ",", 
+   "4", ",", "0", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -3968,9 +3967,9 @@ Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y32.dat\>\""}], ",", "1", ",",
-    "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y32.dat\>\""}], ",", 
+   "1", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -4022,8 +4021,7 @@ Cell[TextData[{
  Cell[BoxData[
   FormBox[
    SubscriptBox["\[CapitalTheta]", 
-    RowBox[{"1", "/", "2"}]], TraditionalForm]],
-  FormatType->TraditionalForm,ExpressionUUID->
+    RowBox[{"1", "/", "2"}]], TraditionalForm]],ExpressionUUID->
   "c933f8f7-a996-4e10-8cac-3d7627ee1e71"],
  " and ",
  Cell[BoxData[
@@ -4046,9 +4044,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y_12_32_CustoDegen.dat\>\""}],
-    ",", "4", ",", "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y_12_32_CustoDegen.dat\>\
+\""}], ",", "4", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -4086,9 +4084,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y_12_32_CustoDegen.dat\>\""}],
-    ",", "4", ",", "0", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y_12_32_CustoDegen.dat\>\
+\""}], ",", "4", ",", "0", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -4125,9 +4123,9 @@ Cell[BoxData[
  RowBox[{"matchResToMasScanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/MatchingResult_EW_Quad_Y_12_32_CustoDegen.dat\>\""}],
-    ",", "1", ",", "1", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/MatchingResult_EW_Quad_Y_12_32_CustoDegen.dat\>\
+\""}], ",", "1", ",", "1", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -4160,7 +4158,7 @@ Cell[BoxData[
  CellChangeTimes->{{3.942744134878532*^9, 3.942744150582365*^9}},
  CellLabel->"In[70]:=",ExpressionUUID->"683c6eb2-e32b-4448-aa97-cb3c16be88de"]
 }, Open  ]]
-}, Closed]],
+}, Open  ]],
 
 Cell[CellGroupData[{
 
@@ -4230,19 +4228,19 @@ Cell[BoxData[
     RowBox[{"condFlaSym", "=", 
      RowBox[{"Get", "[", 
       RowBox[{
-       RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-       "\"\</sample_results/Granada_Collection/Flavour_Sym_Cond_SMEFiT_Tree_\
-Level_Mod_\>\"", "<>", 
-       RowBox[{"ToString", "[", "ii", "]"}], "<>", 
-       "\"\<_25_07_2025.dat\>\""}], "]"}]}], ";", "\[IndentingNewLine]", 
+       RowBox[{"NotebookDirectory", "[", "]"}], 
+       "<>", "\"\</sample_results/Granada_Collection/Flavour_Sym_Cond_SMEFiT_\
+Tree_Level_Mod_\>\"", "<>", 
+       RowBox[{"ToString", "[", "ii", "]"}], 
+       "<>", "\"\<_25_07_2025.dat\>\""}], "]"}]}], ";", "\[IndentingNewLine]", 
     RowBox[{"matchResToUVscanCard", "[", 
      RowBox[{
       RowBox[{
-       RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-       "\"\</sample_results/Granada_Collection/Matching_Result_Tree_Level_Mod_\
-\>\"", "<>", 
-       RowBox[{"ToString", "[", "ii", "]"}], "<>", 
-       "\"\<_25_07_2025.dat\>\""}], ",", "1", ",", "0", ",", 
+       RowBox[{"NotebookDirectory", "[", "]"}], 
+       "<>", "\"\</sample_results/Granada_Collection/Matching_Result_Tree_\
+Level_Mod_\>\"", "<>", 
+       RowBox[{"ToString", "[", "ii", "]"}], 
+       "<>", "\"\<_25_07_2025.dat\>\""}], ",", "1", ",", "0", ",", 
       RowBox[{"{", 
        RowBox[{
         RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -4677,19 +4675,19 @@ Cell[BoxData[
     RowBox[{"condFlaSym", "=", 
      RowBox[{"Get", "[", 
       RowBox[{
-       RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-       "\"\</sample_results/Granada_Collection/Flavour_Sym_Cond_SMEFiT_Tree_\
-Level_Mod_\>\"", "<>", 
-       RowBox[{"ToString", "[", "ii", "]"}], "<>", 
-       "\"\<_25_07_2025.dat\>\""}], "]"}]}], ";", "\[IndentingNewLine]", 
+       RowBox[{"NotebookDirectory", "[", "]"}], 
+       "<>", "\"\</sample_results/Granada_Collection/Flavour_Sym_Cond_SMEFiT_\
+Tree_Level_Mod_\>\"", "<>", 
+       RowBox[{"ToString", "[", "ii", "]"}], 
+       "<>", "\"\<_25_07_2025.dat\>\""}], "]"}]}], ";", "\[IndentingNewLine]", 
     RowBox[{"matchResToMasScanCard", "[", 
      RowBox[{
       RowBox[{
-       RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-       "\"\</sample_results/Granada_Collection/Matching_Result_Tree_Level_Mod_\
-\>\"", "<>", 
-       RowBox[{"ToString", "[", "ii", "]"}], "<>", 
-       "\"\<_25_07_2025.dat\>\""}], ",", "1", ",", "0", ",", 
+       RowBox[{"NotebookDirectory", "[", "]"}], 
+       "<>", "\"\</sample_results/Granada_Collection/Matching_Result_Tree_\
+Level_Mod_\>\"", "<>", 
+       RowBox[{"ToString", "[", "ii", "]"}], 
+       "<>", "\"\<_25_07_2025.dat\>\""}], ",", "1", ",", "0", ",", 
       RowBox[{"{", 
        RowBox[{
         RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -6122,7 +6120,7 @@ In[72]:=",ExpressionUUID->"eafa4e99-b51d-4e83-a60a-0fa4ccb2a2be"]
 }, Open  ]]
 }, Closed]]
 }, Open  ]]
-}, Closed]],
+}, Open  ]],
 
 Cell[CellGroupData[{
 
@@ -6317,8 +6315,7 @@ Cell[BoxData[{
        RowBox[{"{", 
         RowBox[{"0.`", ",", "0.`", ",", 
          RowBox[{"-", "0.16666666666666666`"}]}], "}"}], "}"}], "}"}], ",", 
-     RowBox[{"{", "3", "}"}]}], "]"}], ",", "2"}], 
-  "]"}], "\[IndentingNewLine]", 
+     RowBox[{"{", "3", "}"}]}], "]"}], ",", "2"}], "]"}], "\[IndentingNewLine]", 
  RowBox[{"Dimensions", "[", "%", "]"}]}], "Input",
  CellChangeTimes->{{3.9624375632206097`*^9, 3.962437668079199*^9}, {
    3.962437726777445*^9, 3.962437796386587*^9}, 3.9624381040289993`*^9, {
@@ -6339,8 +6336,7 @@ Cell[BoxData[
       RowBox[{"\<\"gGdf11\"\>", ",", "\<\"0.\"\>", ",", "\<\"0\"\>"}], "}"}], 
      ",", 
      RowBox[{"{", 
-      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], ",", 
      RowBox[{"{", 
       RowBox[{"\<\"gGuf33\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}]}],
      "}"}], ",", 
@@ -6350,8 +6346,7 @@ Cell[BoxData[
       RowBox[{"\<\"gGdf11\"\>", ",", "\<\"0.\"\>", ",", "\<\"0\"\>"}], "}"}], 
      ",", 
      RowBox[{"{", 
-      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], ",", 
      RowBox[{"{", 
       RowBox[{"\<\"gGuf33\"\>", ",", "\<\"1\"\>", ",", "\<\"1\"\>"}], "}"}]}],
      "}"}], ",", 
@@ -6361,8 +6356,7 @@ Cell[BoxData[
       RowBox[{"\<\"gGdf11\"\>", ",", "\<\"-0.16666666666666666\"\>", 
        ",", "\<\"0\"\>"}], "}"}], ",", 
      RowBox[{"{", 
-      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], ",", 
      RowBox[{"{", 
       RowBox[{"\<\"gGuf33\"\>", ",", "\<\"1\"\>", ",", "\<\"2\"\>"}], "}"}]}],
      "}"}]}], "}"}]], "Output",
@@ -6399,8 +6393,7 @@ Cell[BoxData[{
        RowBox[{"{", 
         RowBox[{"0.`", ",", "0.`", ",", 
          RowBox[{"-", "0.16666666666666666`"}]}], "}"}], "}"}], "}"}], ",", 
-     RowBox[{"{", "3", "}"}]}], "]"}], ",", "2"}], 
-  "]"}], "\[IndentingNewLine]", 
+     RowBox[{"{", "3", "}"}]}], "]"}], ",", "2"}], "]"}], "\[IndentingNewLine]", 
  RowBox[{"Dimensions", "[", "%", "]"}]}], "Input",
  CellChangeTimes->{3.963019472276362*^9},
  CellLabel->"In[19]:=",ExpressionUUID->"ee4b5200-0654-4297-afa2-59e1eebd0c4d"],
@@ -6486,8 +6479,7 @@ Cell[BoxData[{
          RowBox[{"{", 
           RowBox[{"0.`", ",", 
            RowBox[{"-", "1.`"}]}], "}"}]}], "}"}], "}"}], "}"}], ",", 
-     RowBox[{"{", "4", "}"}]}], "]"}], ",", "3"}], 
-  "]"}], "\[IndentingNewLine]", 
+     RowBox[{"{", "4", "}"}]}], "]"}], ",", "3"}], "]"}], "\[IndentingNewLine]", 
  RowBox[{"Dimensions", "[", "%", "]"}], "\[IndentingNewLine]", 
  RowBox[{
   RowBox[{"Flatten", "[", 
@@ -6508,42 +6500,33 @@ Cell[BoxData[
    RowBox[{"{", 
     RowBox[{
      RowBox[{"{", 
-      RowBox[{"\<\"dummy\"\>", ",", "\<\"0.\"\>", ",", "\<\"0\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"dummy\"\>", ",", "\<\"0.\"\>", ",", "\<\"0\"\>"}], "}"}], ",", 
      RowBox[{"{", 
-      RowBox[{"\<\"gGdf11\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"gGdf11\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], ",", 
      RowBox[{"{", 
-      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], ",", 
      RowBox[{"{", 
       RowBox[{"\<\"gGuf33\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}]}],
      "}"}], ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"{", 
-      RowBox[{"\<\"dummy\"\>", ",", "\<\"0.\"\>", ",", "\<\"0\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"dummy\"\>", ",", "\<\"0.\"\>", ",", "\<\"0\"\>"}], "}"}], ",", 
      RowBox[{"{", 
-      RowBox[{"\<\"gGdf11\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"gGdf11\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], ",", 
      RowBox[{"{", 
-      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], ",", 
      RowBox[{"{", 
       RowBox[{"\<\"gGuf33\"\>", ",", "\<\"1\"\>", ",", "\<\"1\"\>"}], "}"}]}],
      "}"}], ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"{", 
-      RowBox[{"\<\"dummy\"\>", ",", "\<\"0.\"\>", ",", "\<\"0\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"dummy\"\>", ",", "\<\"0.\"\>", ",", "\<\"0\"\>"}], "}"}], ",", 
      RowBox[{"{", 
-      RowBox[{"\<\"gGdf11\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"gGdf11\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], ",", 
      RowBox[{"{", 
-      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"1\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"1\"\>"}], "}"}], ",", 
      RowBox[{"{", 
       RowBox[{"\<\"gGuf33\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}]}],
      "}"}], ",", 
@@ -6553,11 +6536,9 @@ Cell[BoxData[
       RowBox[{"\<\"dummy\"\>", ",", "\<\"-1.\"\>", ",", "\<\"0\"\>"}], "}"}], 
      ",", 
      RowBox[{"{", 
-      RowBox[{"\<\"gGdf11\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"gGdf11\"\>", ",", "\<\"1\"\>", ",", "\<\"0\"\>"}], "}"}], ",", 
      RowBox[{"{", 
-      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"1\"\>"}], "}"}], 
-     ",", 
+      RowBox[{"\<\"gGqf33\"\>", ",", "\<\"1\"\>", ",", "\<\"1\"\>"}], "}"}], ",", 
      RowBox[{"{", 
       RowBox[{"\<\"gGuf33\"\>", ",", "\<\"1\"\>", ",", "\<\"1\"\>"}], "}"}]}],
      "}"}]}], "}"}]], "Output",
@@ -6604,8 +6585,7 @@ Cell[BoxData[{
           RowBox[{"dummy", "^", "2"}], "/", "3"}], "+", 
          RowBox[{"dummy", "/", "6"}]}], ",", 
         RowBox[{"{", "dummy", "}"}]}], "]"}], "]"}], ",", 
-     RowBox[{"{", "1", "}"}]}], "]"}], ",", "1"}], 
-  "]"}], "\[IndentingNewLine]", 
+     RowBox[{"{", "1", "}"}]}], "]"}], ",", "1"}], "]"}], "\[IndentingNewLine]", 
  RowBox[{
   RowBox[{"Flatten", "[", 
    RowBox[{"%", "[", 
@@ -6621,8 +6601,7 @@ Cell[BoxData[
  RowBox[{"{", 
   RowBox[{
    RowBox[{"{", 
-    RowBox[{"\<\"dummy\"\>", ",", "\<\"0.\"\>", ",", "\<\"0\"\>"}], "}"}], 
-   ",", 
+    RowBox[{"\<\"dummy\"\>", ",", "\<\"0.\"\>", ",", "\<\"0\"\>"}], "}"}], ",", 
    RowBox[{"{", 
     RowBox[{"\<\"dummy\"\>", ",", "\<\"0.16666666666666666\"\>", 
      ",", "\<\"1\"\>"}], "}"}], ",", 
@@ -6705,8 +6684,7 @@ Cell[BoxData[{
     FractionBox[
      SuperscriptBox["gGuf33", "2"], "6"]}], ",", 
    RowBox[{"{", 
-    RowBox[{"gGdf11", ",", "gGqf33", ",", "gGuf33"}], "}"}]}], 
-  "]"}], "\[IndentingNewLine]", 
+    RowBox[{"gGdf11", ",", "gGqf33", ",", "gGuf33"}], "}"}]}], "]"}], "\[IndentingNewLine]", 
  RowBox[{"CoefficientList", "[", 
   RowBox[{
    RowBox[{"-", 
@@ -6769,11 +6747,11 @@ Cell[BoxData[
  RowBox[{"dictionaryToPrint", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/Granada_Collection/Matching_Result_Tree_Level_Mod_\>\
-\"", "<>", 
-    RowBox[{"ToString", "[", "25", "]"}], "<>", "\"\<_25_07_2025.dat\>\""}], 
-   ",", "0"}], "]"}]], "Input",
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/Granada_Collection/Matching_Result_Tree_Level_\
+Mod_\>\"", "<>", 
+    RowBox[{"ToString", "[", "25", "]"}], "<>", "\"\<_25_07_2025.dat\>\""}], ",",
+    "0"}], "]"}]], "Input",
  CellChangeTimes->{{3.9624370654796457`*^9, 3.962437073734557*^9}},
  CellLabel->"In[29]:=",ExpressionUUID->"28be093b-8c75-4575-b886-ed4c2268ec21"],
 
@@ -7043,9 +7021,9 @@ Cell[BoxData[
  RowBox[{"matchResToUVscanCard", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\</sample_results/Granada_Collection/Matching_Result_Tree_Level_Mod_47_\
-18_07_2025.dat\>\""}], ",", "1", ",", "0", ",", 
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\</sample_results/Granada_Collection/Matching_Result_Tree_Level_\
+Mod_47_18_07_2025.dat\>\""}], ",", "1", ",", "0", ",", 
    RowBox[{"{", 
     RowBox[{
      RowBox[{"\"\<UVFlavourAssumption\>\"", "->", 
@@ -9454,9 +9432,9 @@ Cell[BoxData[
  RowBox[{"dictionaryToPrint", "[", 
   RowBox[{
    RowBox[{
-    RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
-    "\"\<./sample_results/MatchingResult_EW_Quad_Y12.dat\>\""}], ",", "1"}], 
-  "]"}]], "Input",
+    RowBox[{"NotebookDirectory", "[", "]"}], 
+    "<>", "\"\<./sample_results/MatchingResult_EW_Quad_Y12.dat\>\""}], ",", 
+   "1"}], "]"}]], "Input",
  CellChangeTimes->{{3.942729905330324*^9, 3.942729934603444*^9}},
  CellLabel->"In[40]:=",ExpressionUUID->"e7b328ba-426f-4d21-99ac-fb9d5bf97cce"],
 
@@ -13994,12 +13972,12 @@ Cell[BoxData["True"], "Output",
 }, Closed]]
 },
 WindowToolbars->{"EditBar", "MultipurposeBar"},
-WindowSize->{1214.25, 1032.},
-WindowMargins->{{Automatic, 0}, {Automatic, 0}},
+WindowSize->{933, 1032},
+WindowMargins->{{0, Automatic}, {Automatic, 0}},
 TaggingRules->{
  "WelcomeScreenSettings" -> {"FEStarting" -> False}, "TryRealOnly" -> False},
 Magnification:>1.1 Inherited,
-FrontEndVersion->"13.2 for Linux x86 (64-bit) (December 7, 2022)",
+FrontEndVersion->"14.3 for Linux x86 (64-bit) (July 8, 2025)",
 StyleDefinitions->"Default.nb",
 ExpressionUUID->"4bc9f417-469c-4b25-b672-e3ca4bfee20d"
 ]
@@ -14015,752 +13993,752 @@ CellTagsIndex->{}
 (*NotebookFileOutline
 Notebook[{
 Cell[CellGroupData[{
-Cell[580, 22, 328, 6, 50, "Input",ExpressionUUID->"724d1669-2d7f-4a85-a71e-08a37e5e21cc",
+Cell[580, 22, 328, 6, 49, "Input",ExpressionUUID->"724d1669-2d7f-4a85-a71e-08a37e5e21cc",
  InitializationCell->True],
-Cell[911, 30, 1925, 27, 37, "Output",ExpressionUUID->"aca17ebb-f6dd-4007-a11f-d8eba66ed5e8",
+Cell[911, 30, 1951, 28, 36, "Output",ExpressionUUID->"7067e07f-d31b-4325-bb06-4dadc608a42f",
  InitializationCell->True]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[2873, 62, 355, 6, 50, "Input",ExpressionUUID->"213bbee4-ce8a-41f6-a532-dc0c045e4857",
+Cell[2899, 63, 355, 6, 49, "Input",ExpressionUUID->"213bbee4-ce8a-41f6-a532-dc0c045e4857",
  InitializationCell->True],
 Cell[CellGroupData[{
-Cell[3253, 72, 2448, 36, 48, "Print",ExpressionUUID->"cde55186-c21c-4d71-adf6-66319b25d4cc"],
-Cell[5704, 110, 2397, 35, 27, "Print",ExpressionUUID->"ddf8425d-341f-43d0-ae49-a5073752ab27"],
-Cell[8104, 147, 2400, 35, 27, "Print",ExpressionUUID->"ac7f667c-ea94-48b0-a7e0-7dc9bb12f4fe"],
-Cell[10507, 184, 2407, 35, 27, "Print",ExpressionUUID->"1c36331b-20a5-46ba-94fe-247be3643574"],
-Cell[12917, 221, 2466, 36, 27, "Print",ExpressionUUID->"c9414602-8680-43b6-8440-62ebb5c6742c"]
+Cell[3279, 73, 2474, 37, 46, "Print",ExpressionUUID->"2604e2b8-af09-49c2-9306-c8a7bc1126ed"],
+Cell[5756, 112, 2425, 36, 25, "Print",ExpressionUUID->"52003550-0ef8-4cea-8627-53e86ada7a92"],
+Cell[8184, 150, 2428, 36, 25, "Print",ExpressionUUID->"3be8298d-cefc-4ede-84d4-c4f800e52bff"],
+Cell[10615, 188, 2435, 36, 25, "Print",ExpressionUUID->"bf445ea2-dce5-4ab8-844e-143f9a89f497"],
+Cell[13053, 226, 2494, 37, 25, "Print",ExpressionUUID->"1123ae48-1878-47fd-96f8-6c7cbb0b8f6c"]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[15432, 263, 175, 3, 74, "Section",ExpressionUUID->"11868b05-fd24-da4c-865e-708cb840a691"],
-Cell[15610, 268, 445, 9, 63, "Text",ExpressionUUID->"88d20821-949c-4e2e-b2f0-9618de36d102"],
+Cell[15596, 269, 175, 3, 72, "Section",ExpressionUUID->"11868b05-fd24-da4c-865e-708cb840a691"],
+Cell[15774, 274, 445, 9, 61, "Text",ExpressionUUID->"88d20821-949c-4e2e-b2f0-9618de36d102"],
 Cell[CellGroupData[{
-Cell[16080, 281, 336, 7, 31, "Input",ExpressionUUID->"88bb3d97-2056-4043-ba3f-8c71127f7c16"],
-Cell[16419, 290, 585, 11, 77, "Output",ExpressionUUID->"2ee828d2-8b7a-49e2-9e20-37eb61075b69"]
+Cell[16244, 287, 336, 7, 32, "Input",ExpressionUUID->"88bb3d97-2056-4043-ba3f-8c71127f7c16"],
+Cell[16583, 296, 585, 11, 36, "Output",ExpressionUUID->"2ee828d2-8b7a-49e2-9e20-37eb61075b69"]
 }, Open  ]],
-Cell[17019, 304, 496, 9, 63, "Text",ExpressionUUID->"903f8921-e684-4890-b0de-f9ed15f0e822"],
+Cell[17183, 310, 496, 9, 109, "Text",ExpressionUUID->"903f8921-e684-4890-b0de-f9ed15f0e822"],
 Cell[CellGroupData[{
-Cell[17540, 317, 345, 8, 31, "Input",ExpressionUUID->"37c34ea8-8b1f-4414-a539-62e926caf03e"],
-Cell[17888, 327, 301, 7, 77, "Output",ExpressionUUID->"be17913d-428b-4269-8540-f74ecf0fdd90"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[18226, 339, 501, 10, 31, "Input",ExpressionUUID->"73ee33cc-d320-4b8a-8e6b-e9cf852ce57e"],
-Cell[18730, 351, 625, 12, 77, "Output",ExpressionUUID->"d4b5d9b2-57a7-4352-8deb-8e92c4809d3c"]
+Cell[17704, 323, 345, 8, 54, "Input",ExpressionUUID->"37c34ea8-8b1f-4414-a539-62e926caf03e"],
+Cell[18052, 333, 301, 7, 36, "Output",ExpressionUUID->"be17913d-428b-4269-8540-f74ecf0fdd90"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[19392, 368, 411, 9, 31, "Input",ExpressionUUID->"66af303e-cb67-4d5b-9327-cda4b4801186"],
-Cell[19806, 379, 422, 10, 77, "Output",ExpressionUUID->"118974e5-2bc2-42da-9c1a-12f0bd5f50c8"]
-}, Open  ]],
-Cell[20243, 392, 262, 6, 38, "Text",ExpressionUUID->"f479a9ac-6bd0-4786-b858-8319c0111056"],
-Cell[CellGroupData[{
-Cell[20530, 402, 340, 7, 31, "Input",ExpressionUUID->"fbd111ae-d2ff-405b-a4f9-558d1308b398"],
-Cell[20873, 411, 558, 13, 77, "Output",ExpressionUUID->"7203d81c-75bc-4e67-af10-b5527341ff0f"]
+Cell[18390, 345, 502, 10, 54, "Input",ExpressionUUID->"73ee33cc-d320-4b8a-8e6b-e9cf852ce57e"],
+Cell[18895, 357, 625, 12, 36, "Output",ExpressionUUID->"d4b5d9b2-57a7-4352-8deb-8e92c4809d3c"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[21468, 429, 405, 8, 31, "Input",ExpressionUUID->"55aefbc4-27ec-4de2-82a6-32374989edbe"],
-Cell[21876, 439, 539, 12, 77, "Output",ExpressionUUID->"4fe8d63a-d7ad-40df-a22f-4534a13db5ba"]
+Cell[19557, 374, 412, 9, 54, "Input",ExpressionUUID->"66af303e-cb67-4d5b-9327-cda4b4801186"],
+Cell[19972, 385, 422, 10, 36, "Output",ExpressionUUID->"118974e5-2bc2-42da-9c1a-12f0bd5f50c8"]
+}, Open  ]],
+Cell[20409, 398, 262, 6, 37, "Text",ExpressionUUID->"f479a9ac-6bd0-4786-b858-8319c0111056"],
+Cell[CellGroupData[{
+Cell[20696, 408, 340, 7, 32, "Input",ExpressionUUID->"fbd111ae-d2ff-405b-a4f9-558d1308b398"],
+Cell[21039, 417, 558, 13, 36, "Output",ExpressionUUID->"7203d81c-75bc-4e67-af10-b5527341ff0f"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[21634, 435, 403, 8, 77, "Input",ExpressionUUID->"55aefbc4-27ec-4de2-82a6-32374989edbe"],
+Cell[22040, 445, 539, 12, 77, "Output",ExpressionUUID->"4fe8d63a-d7ad-40df-a22f-4534a13db5ba"]
 }, Open  ]]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[22464, 457, 228, 4, 58, "Section",ExpressionUUID->"bab2c408-f486-3b4e-aae3-0268ee26220b"],
-Cell[22695, 463, 873, 25, 71, "Text",ExpressionUUID->"04922d96-f706-449d-9407-a4ca0786a3ca"],
+Cell[22628, 463, 228, 4, 56, "Section",ExpressionUUID->"bab2c408-f486-3b4e-aae3-0268ee26220b"],
+Cell[22859, 469, 873, 25, 66, "Text",ExpressionUUID->"04922d96-f706-449d-9407-a4ca0786a3ca"],
 Cell[CellGroupData[{
-Cell[23593, 492, 328, 6, 33, "Input",ExpressionUUID->"ca8531b3-54e3-41e7-957e-d1a8ccfef51c"],
+Cell[23757, 498, 328, 6, 32, "Input",ExpressionUUID->"ca8531b3-54e3-41e7-957e-d1a8ccfef51c"],
 Cell[CellGroupData[{
-Cell[23946, 502, 252, 5, 25, "Print",ExpressionUUID->"01155752-b849-4757-9d90-99e511d318fe"],
-Cell[24201, 509, 358, 6, 28, "Print",ExpressionUUID->"6df54c34-8622-4f78-bd96-31aec87766dd"]
+Cell[24110, 508, 252, 5, 25, "Print",ExpressionUUID->"01155752-b849-4757-9d90-99e511d318fe"],
+Cell[24365, 515, 358, 6, 26, "Print",ExpressionUUID->"6df54c34-8622-4f78-bd96-31aec87766dd"]
 }, Open  ]]
 }, Open  ]],
-Cell[24586, 519, 335, 7, 63, "Text",ExpressionUUID->"aa22fd97-325c-4138-aa87-62e5546b0a60"],
+Cell[24750, 525, 335, 7, 61, "Text",ExpressionUUID->"aa22fd97-325c-4138-aa87-62e5546b0a60"],
 Cell[CellGroupData[{
-Cell[24946, 530, 415, 8, 33, "Input",ExpressionUUID->"156cd0dd-cb16-4ce3-a668-b762094f9f16"],
+Cell[25110, 536, 418, 9, 32, "Input",ExpressionUUID->"156cd0dd-cb16-4ce3-a668-b762094f9f16"],
 Cell[CellGroupData[{
-Cell[25386, 542, 305, 5, 27, "Print",ExpressionUUID->"429baece-1197-4993-b2cb-e6b297d75379"],
-Cell[25694, 549, 205, 4, 25, "Print",ExpressionUUID->"43f86948-272d-4666-a65e-f80926603a4f"],
-Cell[25902, 555, 311, 5, 28, "Print",ExpressionUUID->"f0486e7b-f2d7-4b24-996f-3b5381ccd8c1"]
+Cell[25553, 549, 305, 5, 46, "Print",ExpressionUUID->"429baece-1197-4993-b2cb-e6b297d75379"],
+Cell[25861, 556, 205, 4, 25, "Print",ExpressionUUID->"43f86948-272d-4666-a65e-f80926603a4f"],
+Cell[26069, 562, 311, 5, 26, "Print",ExpressionUUID->"f0486e7b-f2d7-4b24-996f-3b5381ccd8c1"]
 }, Open  ]]
 }, Open  ]],
-Cell[26240, 564, 242, 4, 38, "Text",ExpressionUUID->"3fa4c261-1865-4bb0-bdfb-4d19fa0260dc"],
+Cell[26407, 571, 242, 4, 37, "Text",ExpressionUUID->"3fa4c261-1865-4bb0-bdfb-4d19fa0260dc"],
 Cell[CellGroupData[{
-Cell[26507, 572, 402, 8, 57, "Input",ExpressionUUID->"b6af6127-000d-41ab-b002-a3ad732d5646"],
+Cell[26674, 579, 401, 8, 54, "Input",ExpressionUUID->"b6af6127-000d-41ab-b002-a3ad732d5646"],
 Cell[CellGroupData[{
-Cell[26934, 584, 966, 15, 27, "Print",ExpressionUUID->"68b380dc-eec9-4869-b7ee-4edae3ae55ae"],
-Cell[27903, 601, 866, 14, 25, "Print",ExpressionUUID->"98fb4c6b-5d94-4d99-9e33-10a893cab44d"],
-Cell[28772, 617, 972, 15, 28, "Print",ExpressionUUID->"4da70861-f2f7-4ba8-8661-8b1ff5523dc8"]
+Cell[27100, 591, 966, 15, 46, "Print",ExpressionUUID->"68b380dc-eec9-4869-b7ee-4edae3ae55ae"],
+Cell[28069, 608, 866, 14, 25, "Print",ExpressionUUID->"98fb4c6b-5d94-4d99-9e33-10a893cab44d"],
+Cell[28938, 624, 972, 15, 26, "Print",ExpressionUUID->"4da70861-f2f7-4ba8-8661-8b1ff5523dc8"]
 }, Open  ]]
 }, Open  ]],
-Cell[29771, 636, 559, 9, 89, "Text",ExpressionUUID->"f4edd3d6-d345-47af-a003-87dbac548da7"],
-Cell[30333, 647, 329, 6, 38, "Text",ExpressionUUID->"393bd514-0360-42dc-83f1-e1cc2de741ea"],
+Cell[29937, 643, 559, 9, 85, "Text",ExpressionUUID->"f4edd3d6-d345-47af-a003-87dbac548da7"],
+Cell[30499, 654, 329, 6, 38, "Text",ExpressionUUID->"393bd514-0360-42dc-83f1-e1cc2de741ea"],
 Cell[CellGroupData[{
-Cell[30687, 657, 3235, 84, 334, "Input",ExpressionUUID->"2486e1ef-0217-49b2-9adb-65740ed4ce8f"],
+Cell[30853, 664, 3233, 84, 334, "Input",ExpressionUUID->"2486e1ef-0217-49b2-9adb-65740ed4ce8f"],
 Cell[CellGroupData[{
-Cell[33947, 745, 657, 11, 27, "Print",ExpressionUUID->"9de4d878-baad-48f3-8c22-647df3ef15d9"],
-Cell[34607, 758, 555, 10, 25, "Print",ExpressionUUID->"7be4119f-1777-4519-8f13-338faa9d6bfc"],
-Cell[35165, 770, 656, 11, 28, "Print",ExpressionUUID->"36836d6a-3fd5-4647-a7e8-d11a47b847de"]
+Cell[34111, 752, 657, 11, 27, "Print",ExpressionUUID->"9de4d878-baad-48f3-8c22-647df3ef15d9"],
+Cell[34771, 765, 555, 10, 25, "Print",ExpressionUUID->"7be4119f-1777-4519-8f13-338faa9d6bfc"],
+Cell[35329, 777, 656, 11, 28, "Print",ExpressionUUID->"36836d6a-3fd5-4647-a7e8-d11a47b847de"]
 }, Open  ]]
 }, Open  ]],
-Cell[35848, 785, 346, 7, 38, "Text",ExpressionUUID->"a5feb83c-4852-471b-a3f2-d60a4de4b92c"],
+Cell[36012, 792, 346, 7, 38, "Text",ExpressionUUID->"a5feb83c-4852-471b-a3f2-d60a4de4b92c"],
 Cell[CellGroupData[{
-Cell[36219, 796, 3169, 82, 304, "Input",ExpressionUUID->"b9bd5fa0-0c19-4e53-9596-d0339dd98ce6"],
+Cell[36383, 803, 3167, 82, 304, "Input",ExpressionUUID->"b9bd5fa0-0c19-4e53-9596-d0339dd98ce6"],
 Cell[CellGroupData[{
-Cell[39413, 882, 476, 8, 27, "Print",ExpressionUUID->"92341da1-353c-44fc-a72d-b3163e683d47"],
-Cell[39892, 892, 374, 7, 25, "Print",ExpressionUUID->"8ddbf61d-cae2-427e-b94f-bf0d0191a787"]
+Cell[39575, 889, 476, 8, 27, "Print",ExpressionUUID->"92341da1-353c-44fc-a72d-b3163e683d47"],
+Cell[40054, 899, 374, 7, 25, "Print",ExpressionUUID->"8ddbf61d-cae2-427e-b94f-bf0d0191a787"]
 }, Open  ]]
 }, Open  ]],
-Cell[40293, 903, 319, 7, 38, "Text",ExpressionUUID->"639778cf-38ce-4ed0-90a5-8bf152e83c13"],
+Cell[40455, 910, 319, 7, 38, "Text",ExpressionUUID->"639778cf-38ce-4ed0-90a5-8bf152e83c13"],
 Cell[CellGroupData[{
-Cell[40637, 914, 322, 6, 33, "Input",ExpressionUUID->"318ec813-fd03-4b7c-ada8-ce339af3e4bc"],
-Cell[40962, 922, 365, 6, 27, "Print",ExpressionUUID->"7b0e5c70-caab-4f0f-9bf2-608a06809c54"],
-Cell[41330, 930, 1702, 47, 85, "Output",ExpressionUUID->"5b4979d2-38cf-436a-b63e-ddc524edce3b"]
+Cell[40799, 921, 322, 6, 33, "Input",ExpressionUUID->"318ec813-fd03-4b7c-ada8-ce339af3e4bc"],
+Cell[41124, 929, 365, 6, 27, "Print",ExpressionUUID->"7b0e5c70-caab-4f0f-9bf2-608a06809c54"],
+Cell[41492, 937, 1702, 47, 85, "Output",ExpressionUUID->"5b4979d2-38cf-436a-b63e-ddc524edce3b"]
 }, Open  ]],
-Cell[43047, 980, 252, 4, 38, "Text",ExpressionUUID->"02e2fbe1-8e78-43ac-a63b-7638ef9b0568"],
+Cell[43209, 987, 252, 4, 38, "Text",ExpressionUUID->"02e2fbe1-8e78-43ac-a63b-7638ef9b0568"],
 Cell[CellGroupData[{
-Cell[43324, 988, 335, 6, 33, "Input",ExpressionUUID->"925f3b7f-208e-4bee-a0db-7dc703aa60d9"],
+Cell[43486, 995, 338, 7, 33, "Input",ExpressionUUID->"925f3b7f-208e-4bee-a0db-7dc703aa60d9"],
 Cell[CellGroupData[{
-Cell[43684, 998, 361, 6, 27, "Print",ExpressionUUID->"9ef52077-cf9d-41d3-be14-3f34560c2a4b"],
-Cell[44048, 1006, 306, 5, 27, "Print",ExpressionUUID->"bea44fbd-0574-49dd-a282-b699423a93c3"]
+Cell[43849, 1006, 361, 6, 27, "Print",ExpressionUUID->"9ef52077-cf9d-41d3-be14-3f34560c2a4b"],
+Cell[44213, 1014, 306, 5, 27, "Print",ExpressionUUID->"bea44fbd-0574-49dd-a282-b699423a93c3"]
 }, Open  ]],
-Cell[44369, 1014, 1634, 46, 85, "Output",ExpressionUUID->"1a08ae9b-525a-4af0-ad0f-10b0d47f5cde"]
+Cell[44534, 1022, 1634, 46, 85, "Output",ExpressionUUID->"1a08ae9b-525a-4af0-ad0f-10b0d47f5cde"]
 }, Open  ]],
-Cell[46018, 1063, 360, 8, 63, "Text",ExpressionUUID->"573a793c-e637-4ede-9d8b-d32ee89416a8"],
-Cell[46381, 1073, 5309, 152, 546, "Input",ExpressionUUID->"66e02b12-1f28-42cd-b1a0-678a78d919d9",
+Cell[46183, 1071, 360, 8, 63, "Text",ExpressionUUID->"573a793c-e637-4ede-9d8b-d32ee89416a8"],
+Cell[46546, 1081, 5309, 152, 546, "Input",ExpressionUUID->"66e02b12-1f28-42cd-b1a0-678a78d919d9",
  InitializationCell->True],
 Cell[CellGroupData[{
-Cell[51715, 1229, 1189, 21, 57, "Input",ExpressionUUID->"aa26835e-47e6-4441-871a-9201c9fe9e01"],
-Cell[52907, 1252, 899, 14, 27, "Print",ExpressionUUID->"0651f934-4da5-4382-841e-3a8f5f68fce4"],
-Cell[53809, 1268, 1875, 43, 85, "Output",ExpressionUUID->"3fc25c2e-b7cc-4393-bae9-239b43703ca6"]
+Cell[51880, 1237, 1189, 21, 57, "Input",ExpressionUUID->"aa26835e-47e6-4441-871a-9201c9fe9e01"],
+Cell[53072, 1260, 899, 14, 27, "Print",ExpressionUUID->"0651f934-4da5-4382-841e-3a8f5f68fce4"],
+Cell[53974, 1276, 1875, 43, 85, "Output",ExpressionUUID->"3fc25c2e-b7cc-4393-bae9-239b43703ca6"]
 }, Open  ]],
-Cell[55699, 1314, 277, 6, 38, "Text",ExpressionUUID->"0d789c84-b719-48ac-96a1-8d60039785b2"],
+Cell[55864, 1322, 277, 6, 38, "Text",ExpressionUUID->"0d789c84-b719-48ac-96a1-8d60039785b2"],
 Cell[CellGroupData[{
-Cell[56001, 1324, 652, 14, 57, "Input",ExpressionUUID->"a115356e-74fd-4194-9aa9-104600116ec3"],
-Cell[56656, 1340, 428, 7, 25, "Print",ExpressionUUID->"7eb926a0-e997-4593-a83e-005c1c6aa973"]
+Cell[56166, 1332, 652, 14, 57, "Input",ExpressionUUID->"a115356e-74fd-4194-9aa9-104600116ec3"],
+Cell[56821, 1348, 428, 7, 25, "Print",ExpressionUUID->"7eb926a0-e997-4593-a83e-005c1c6aa973"]
 }, Open  ]],
-Cell[57099, 1350, 268, 6, 38, "Text",ExpressionUUID->"c522aad7-327b-4685-b778-aa8f9702f97a"],
+Cell[57264, 1358, 268, 6, 38, "Text",ExpressionUUID->"c522aad7-327b-4685-b778-aa8f9702f97a"],
 Cell[CellGroupData[{
-Cell[57392, 1360, 493, 12, 80, "Input",ExpressionUUID->"acf240cb-9725-4ef0-b2ba-bcd50ae74a55"],
+Cell[57557, 1368, 491, 12, 80, "Input",ExpressionUUID->"acf240cb-9725-4ef0-b2ba-bcd50ae74a55"],
 Cell[CellGroupData[{
-Cell[57910, 1376, 403, 7, 27, "Print",ExpressionUUID->"f3bde322-916a-467b-b8f4-00ac18736771"],
-Cell[58316, 1385, 352, 7, 27, "Print",ExpressionUUID->"3c6f1e1a-42a8-49d4-805f-c69d7a9a76d3"]
+Cell[58073, 1384, 403, 7, 27, "Print",ExpressionUUID->"f3bde322-916a-467b-b8f4-00ac18736771"],
+Cell[58479, 1393, 352, 7, 27, "Print",ExpressionUUID->"3c6f1e1a-42a8-49d4-805f-c69d7a9a76d3"]
 }, Open  ]],
-Cell[58683, 1395, 11023, 248, 380, "Output",ExpressionUUID->"ae7324fd-17bc-4360-b3cf-0e1ad59951f0"]
+Cell[58846, 1403, 11023, 248, 380, "Output",ExpressionUUID->"ae7324fd-17bc-4360-b3cf-0e1ad59951f0"]
 }, Open  ]]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[69755, 1649, 172, 3, 58, "Section",ExpressionUUID->"3b3e36d2-963c-a543-842a-3bd98d0d20b2"],
+Cell[69918, 1657, 172, 3, 56, "Section",ExpressionUUID->"3b3e36d2-963c-a543-842a-3bd98d0d20b2"],
 Cell[CellGroupData[{
-Cell[69952, 1656, 171, 3, 58, "Subsection",ExpressionUUID->"659a5b64-fb07-d14e-b3b6-0017089f3368"],
-Cell[70126, 1661, 427, 8, 63, "Text",ExpressionUUID->"67cc7675-47ed-4d15-8ba1-dfe3a74c27d9"],
-Cell[70556, 1671, 822, 14, 33, "Input",ExpressionUUID->"2f3dd777-c994-4fa3-90f4-a97233093014"],
-Cell[71381, 1687, 788, 13, 114, "Text",ExpressionUUID->"b7c9db8f-a20f-40e1-9fb5-e39aaefec3d6"],
-Cell[72172, 1702, 504, 10, 80, "Input",ExpressionUUID->"844b8a76-4080-44a3-9beb-6efe90a9684e"],
-Cell[72679, 1714, 229, 4, 38, "Text",ExpressionUUID->"6c37cbfe-860c-4697-ab90-767b65c131a5"],
-Cell[72911, 1720, 1944, 40, 127, "Input",ExpressionUUID->"0c759a4c-5d5f-4ac4-8c7d-392a697868e1"],
-Cell[74858, 1762, 348, 7, 38, "Text",ExpressionUUID->"d35a17fe-8837-489d-8b82-91b1478a9ee2"],
-Cell[75209, 1771, 4449, 100, 358, "Input",ExpressionUUID->"fb10fc5a-1ee3-4671-af20-93e98f854304"],
-Cell[79661, 1873, 247, 4, 38, "Text",ExpressionUUID->"480558dd-bf63-42e2-9339-fb1c547b3599"],
-Cell[79911, 1879, 3500, 86, 125, "Input",ExpressionUUID->"770b22be-2b55-4b77-917f-821bc7ee8c3d"],
-Cell[83414, 1967, 290, 3, 38, "Text",ExpressionUUID->"a8cfb921-cabe-4081-9bcd-5b81c2cbc021"],
-Cell[83707, 1972, 1180, 24, 57, "Input",ExpressionUUID->"5dfc6be7-b1fc-4907-b4c0-b4033d117d74"],
-Cell[84890, 1998, 1216, 25, 57, "Input",ExpressionUUID->"49a7ed0c-d7f3-47bd-8b8e-0021ba8c183b"]
-}, Closed]],
-Cell[CellGroupData[{
-Cell[86143, 2028, 171, 3, 40, "Subsection",ExpressionUUID->"e83d7921-8929-4b11-9fa7-6af7542d18a1"],
-Cell[86317, 2033, 321, 7, 40, "Text",ExpressionUUID->"b4d28ae6-c90a-453b-a97b-b26c9246f594"],
-Cell[86641, 2042, 566, 14, 63, "Text",ExpressionUUID->"9db62ec8-14d9-41e9-892e-fed71aa661de"],
-Cell[87210, 2058, 229, 4, 38, "Text",ExpressionUUID->"77b5f969-c23b-4d1d-9b74-b4ae5d7e7842"],
-Cell[CellGroupData[{
-Cell[87464, 2066, 347, 7, 33, "Input",ExpressionUUID->"75767fd4-607b-4c46-b476-5994c64d7432"],
-Cell[87814, 2075, 337, 7, 48, "Print",ExpressionUUID->"7c75368c-728b-4817-81b5-58196e4e7ed3"]
+Cell[70115, 1664, 171, 3, 58, "Subsection",ExpressionUUID->"659a5b64-fb07-d14e-b3b6-0017089f3368"],
+Cell[70289, 1669, 427, 8, 61, "Text",ExpressionUUID->"67cc7675-47ed-4d15-8ba1-dfe3a74c27d9"],
+Cell[70719, 1679, 823, 14, 32, "Input",ExpressionUUID->"2f3dd777-c994-4fa3-90f4-a97233093014"],
+Cell[71545, 1695, 788, 13, 109, "Text",ExpressionUUID->"b7c9db8f-a20f-40e1-9fb5-e39aaefec3d6"],
+Cell[72336, 1710, 502, 10, 77, "Input",ExpressionUUID->"844b8a76-4080-44a3-9beb-6efe90a9684e"],
+Cell[72841, 1722, 229, 4, 37, "Text",ExpressionUUID->"6c37cbfe-860c-4697-ab90-767b65c131a5"],
+Cell[73073, 1728, 1944, 40, 121, "Input",ExpressionUUID->"0c759a4c-5d5f-4ac4-8c7d-392a697868e1"],
+Cell[75020, 1770, 348, 7, 37, "Text",ExpressionUUID->"d35a17fe-8837-489d-8b82-91b1478a9ee2"],
+Cell[75371, 1779, 4447, 100, 315, "Input",ExpressionUUID->"fb10fc5a-1ee3-4671-af20-93e98f854304"],
+Cell[79821, 1881, 247, 4, 37, "Text",ExpressionUUID->"480558dd-bf63-42e2-9339-fb1c547b3599"],
+Cell[80071, 1887, 3498, 86, 315, "Input",ExpressionUUID->"770b22be-2b55-4b77-917f-821bc7ee8c3d"],
+Cell[83572, 1975, 290, 3, 37, "Text",ExpressionUUID->"a8cfb921-cabe-4081-9bcd-5b81c2cbc021"],
+Cell[83865, 1980, 1180, 24, 77, "Input",ExpressionUUID->"5dfc6be7-b1fc-4907-b4c0-b4033d117d74"],
+Cell[85048, 2006, 1216, 25, 77, "Input",ExpressionUUID->"49a7ed0c-d7f3-47bd-8b8e-0021ba8c183b"]
 }, Open  ]],
-Cell[88166, 2085, 298, 7, 38, "Text",ExpressionUUID->"ae681fdb-df93-4436-9ec0-96d17260bc5a"],
 Cell[CellGroupData[{
-Cell[88489, 2096, 469, 11, 33, "Input",ExpressionUUID->"a6c8414a-b193-4a50-910f-c5ccd2b58450"],
-Cell[88961, 2109, 341, 7, 48, "Print",ExpressionUUID->"246f731d-28aa-4e26-9de4-8e11aa7463db"]
+Cell[86301, 2036, 171, 3, 58, "Subsection",ExpressionUUID->"e83d7921-8929-4b11-9fa7-6af7542d18a1"],
+Cell[86475, 2041, 321, 7, 40, "Text",ExpressionUUID->"b4d28ae6-c90a-453b-a97b-b26c9246f594"],
+Cell[86799, 2050, 566, 14, 85, "Text",ExpressionUUID->"9db62ec8-14d9-41e9-892e-fed71aa661de"],
+Cell[87368, 2066, 229, 4, 37, "Text",ExpressionUUID->"77b5f969-c23b-4d1d-9b74-b4ae5d7e7842"],
+Cell[CellGroupData[{
+Cell[87622, 2074, 347, 7, 32, "Input",ExpressionUUID->"75767fd4-607b-4c46-b476-5994c64d7432"],
+Cell[87972, 2083, 337, 7, 46, "Print",ExpressionUUID->"7c75368c-728b-4817-81b5-58196e4e7ed3"]
 }, Open  ]],
-Cell[89317, 2119, 299, 6, 38, "Text",ExpressionUUID->"97869936-582b-4a19-ae95-eda44742865f"],
-Cell[89619, 2127, 313, 7, 33, "Input",ExpressionUUID->"432d52da-199f-45ca-91fa-c864e7cee6c6"],
-Cell[89935, 2136, 315, 6, 38, "Text",ExpressionUUID->"8c27ed09-20ae-4f3e-aac9-520942ca1d41"],
+Cell[88324, 2093, 298, 7, 37, "Text",ExpressionUUID->"ae681fdb-df93-4436-9ec0-96d17260bc5a"],
 Cell[CellGroupData[{
-Cell[90275, 2146, 974, 21, 57, "Input",ExpressionUUID->"cc98d55d-ab3f-4c26-b78b-e14138082085"],
-Cell[91252, 2169, 313, 6, 48, "Print",ExpressionUUID->"b4326a98-80df-4c6d-8a10-206aff82bb7a"]
+Cell[88647, 2104, 467, 10, 54, "Input",ExpressionUUID->"a6c8414a-b193-4a50-910f-c5ccd2b58450"],
+Cell[89117, 2116, 341, 7, 46, "Print",ExpressionUUID->"246f731d-28aa-4e26-9de4-8e11aa7463db"]
 }, Open  ]],
-Cell[91580, 2178, 529, 10, 38, "Text",ExpressionUUID->"ce241abf-8783-4d4f-99d6-ff7915544b36"],
-Cell[92112, 2190, 2172, 46, 127, "Input",ExpressionUUID->"760a7cd4-dfff-49f9-b56f-8607512c710b"],
-Cell[94287, 2238, 392, 8, 38, "Text",ExpressionUUID->"9dc0e8fd-915a-4d98-997c-02f637586a0d"],
+Cell[89473, 2126, 299, 6, 61, "Text",ExpressionUUID->"97869936-582b-4a19-ae95-eda44742865f"],
+Cell[89775, 2134, 313, 7, 32, "Input",ExpressionUUID->"432d52da-199f-45ca-91fa-c864e7cee6c6"],
+Cell[90091, 2143, 315, 6, 37, "Text",ExpressionUUID->"8c27ed09-20ae-4f3e-aac9-520942ca1d41"],
 Cell[CellGroupData[{
-Cell[94704, 2250, 1935, 43, 127, "Input",ExpressionUUID->"e969d331-140a-41bc-b77f-95ba4fca722d"],
-Cell[96642, 2295, 289, 6, 48, "Print",ExpressionUUID->"4c1aa9a3-4048-4d4d-ac41-21d6d99f8f7b"]
+Cell[90431, 2153, 974, 21, 54, "Input",ExpressionUUID->"cc98d55d-ab3f-4c26-b78b-e14138082085"],
+Cell[91408, 2176, 313, 6, 46, "Print",ExpressionUUID->"b4326a98-80df-4c6d-8a10-206aff82bb7a"]
 }, Open  ]],
-Cell[96946, 2304, 315, 7, 38, "Text",ExpressionUUID->"82c88240-e59c-4de4-a0c4-ff67fe882089"],
+Cell[91736, 2185, 529, 10, 61, "Text",ExpressionUUID->"ce241abf-8783-4d4f-99d6-ff7915544b36"],
+Cell[92268, 2197, 2172, 46, 144, "Input",ExpressionUUID->"760a7cd4-dfff-49f9-b56f-8607512c710b"],
+Cell[94443, 2245, 392, 8, 38, "Text",ExpressionUUID->"9dc0e8fd-915a-4d98-997c-02f637586a0d"],
 Cell[CellGroupData[{
-Cell[97286, 2315, 7333, 181, 396, "Input",ExpressionUUID->"17f8cdb8-4250-4d5d-b6b8-eedb2bc2860f"],
+Cell[94860, 2257, 1935, 43, 127, "Input",ExpressionUUID->"e969d331-140a-41bc-b77f-95ba4fca722d"],
+Cell[96798, 2302, 289, 6, 48, "Print",ExpressionUUID->"4c1aa9a3-4048-4d4d-ac41-21d6d99f8f7b"]
+}, Open  ]],
+Cell[97102, 2311, 315, 7, 38, "Text",ExpressionUUID->"82c88240-e59c-4de4-a0c4-ff67fe882089"],
 Cell[CellGroupData[{
-Cell[104644, 2500, 388, 7, 48, "Print",ExpressionUUID->"3f940968-4c0c-4820-b3f2-ff1d0cf72138"],
-Cell[105035, 2509, 342, 7, 48, "Print",ExpressionUUID->"4915a712-30e9-4c21-8647-e6e04888bcf1"]
+Cell[97442, 2322, 7320, 179, 396, "Input",ExpressionUUID->"17f8cdb8-4250-4d5d-b6b8-eedb2bc2860f"],
+Cell[CellGroupData[{
+Cell[104787, 2505, 388, 7, 48, "Print",ExpressionUUID->"3f940968-4c0c-4820-b3f2-ff1d0cf72138"],
+Cell[105178, 2514, 342, 7, 48, "Print",ExpressionUUID->"4915a712-30e9-4c21-8647-e6e04888bcf1"]
 }, Open  ]]
 }, Open  ]]
-}, Open  ]]
+}, Closed]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[105450, 2524, 188, 3, 74, "Section",ExpressionUUID->"9dc879c2-41f7-416d-9732-5fec4cccc7e4"],
-Cell[105641, 2529, 1563, 37, 154, "Input",ExpressionUUID->"c1300c96-257c-4dca-89ca-0327ed5bab35"],
-Cell[107207, 2568, 1239, 30, 100, "Input",ExpressionUUID->"f30bb82e-b7f3-40ac-b81f-f9d051d60fed"],
-Cell[108449, 2600, 1242, 30, 100, "Input",ExpressionUUID->"8246a286-442c-403b-8377-2ed1ec6bee7c"],
-Cell[109694, 2632, 929, 21, 57, "Input",ExpressionUUID->"7cb27933-7af1-490f-a55a-258077c3b863"],
-Cell[110626, 2655, 3363, 84, 231, "Input",ExpressionUUID->"d7014b3d-ee1e-4d2b-ba34-d9ac7f121193"],
-Cell[113992, 2741, 1334, 32, 104, "Input",ExpressionUUID->"aacf9821-3826-41fd-9083-d7f226471680"],
-Cell[115329, 2775, 1335, 32, 104, "Input",ExpressionUUID->"c6330cea-6e99-4dd5-86b9-33e308c8260b"],
-Cell[116667, 2809, 1340, 32, 104, "Input",ExpressionUUID->"07e9b006-33a3-443d-b81e-8145a893f8b0"],
-Cell[118010, 2843, 1316, 32, 104, "Input",ExpressionUUID->"7516f598-1283-4061-aa94-f0ab48871018"],
-Cell[119329, 2877, 1337, 32, 104, "Input",ExpressionUUID->"83069df7-95a9-4342-89a1-53be5260159c"],
-Cell[120669, 2911, 1566, 37, 154, "Input",ExpressionUUID->"0dfc20bf-d425-4659-b806-d0fd7d985868"],
-Cell[122238, 2950, 1264, 30, 100, "Input",ExpressionUUID->"adf0502d-12d9-4a9e-b126-990479c984d3"],
-Cell[123505, 2982, 1266, 30, 100, "Input",ExpressionUUID->"6cda8186-223c-4ab1-9a10-5ff09072e54a"],
-Cell[124774, 3014, 854, 19, 80, "Input",ExpressionUUID->"56e8e3da-ee48-409e-bd3b-5dd81ae4877f"],
-Cell[125631, 3035, 1205, 26, 60, "Code",ExpressionUUID->"d87b0cb9-454e-4722-a903-791123a74dca",
+Cell[105593, 2529, 188, 3, 72, "Section",ExpressionUUID->"9dc879c2-41f7-416d-9732-5fec4cccc7e4"],
+Cell[105784, 2534, 1561, 37, 178, "Input",ExpressionUUID->"c1300c96-257c-4dca-89ca-0327ed5bab35"],
+Cell[107348, 2573, 1239, 30, 156, "Input",ExpressionUUID->"f30bb82e-b7f3-40ac-b81f-f9d051d60fed"],
+Cell[108590, 2605, 1242, 30, 156, "Input",ExpressionUUID->"8246a286-442c-403b-8377-2ed1ec6bee7c"],
+Cell[109835, 2637, 929, 21, 77, "Input",ExpressionUUID->"7cb27933-7af1-490f-a55a-258077c3b863"],
+Cell[110767, 2660, 3361, 84, 315, "Input",ExpressionUUID->"d7014b3d-ee1e-4d2b-ba34-d9ac7f121193"],
+Cell[114131, 2746, 1333, 32, 144, "Input",ExpressionUUID->"aacf9821-3826-41fd-9083-d7f226471680"],
+Cell[115467, 2780, 1335, 32, 144, "Input",ExpressionUUID->"c6330cea-6e99-4dd5-86b9-33e308c8260b"],
+Cell[116805, 2814, 1340, 32, 144, "Input",ExpressionUUID->"07e9b006-33a3-443d-b81e-8145a893f8b0"],
+Cell[118148, 2848, 1315, 32, 144, "Input",ExpressionUUID->"7516f598-1283-4061-aa94-f0ab48871018"],
+Cell[119466, 2882, 1336, 32, 144, "Input",ExpressionUUID->"83069df7-95a9-4342-89a1-53be5260159c"],
+Cell[120805, 2916, 1564, 37, 178, "Input",ExpressionUUID->"0dfc20bf-d425-4659-b806-d0fd7d985868"],
+Cell[122372, 2955, 1264, 30, 156, "Input",ExpressionUUID->"adf0502d-12d9-4a9e-b126-990479c984d3"],
+Cell[123639, 2987, 1266, 30, 156, "Input",ExpressionUUID->"6cda8186-223c-4ab1-9a10-5ff09072e54a"],
+Cell[124908, 3019, 854, 19, 77, "Input",ExpressionUUID->"56e8e3da-ee48-409e-bd3b-5dd81ae4877f"],
+Cell[125765, 3040, 1204, 26, 60, "Code",ExpressionUUID->"d87b0cb9-454e-4722-a903-791123a74dca",
  InitializationCell->False]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[126873, 3066, 272, 6, 74, "Section",ExpressionUUID->"c472cf08-de38-495d-a17e-c06c1104f201"],
+Cell[127006, 3071, 272, 6, 72, "Section",ExpressionUUID->"c472cf08-de38-495d-a17e-c06c1104f201"],
 Cell[CellGroupData[{
-Cell[127170, 3076, 167, 3, 58, "Subsection",ExpressionUUID->"c9e7de1b-f319-4924-93ca-7598bf3b47c8"],
+Cell[127303, 3081, 167, 3, 58, "Subsection",ExpressionUUID->"c9e7de1b-f319-4924-93ca-7598bf3b47c8"],
 Cell[CellGroupData[{
-Cell[127362, 3083, 157, 3, 49, "Subsubsection",ExpressionUUID->"22143b24-4e20-4413-a6ab-841320008ba6"],
-Cell[127522, 3088, 685, 16, 63, "Text",ExpressionUUID->"b4bc069c-6d32-4c89-9cd8-7339f96ce12b"],
-Cell[128210, 3106, 192, 3, 38, "Text",ExpressionUUID->"496c1129-12e6-4392-a55d-39eb6f7e7d23"],
-Cell[128405, 3111, 1552, 36, 78, "Input",ExpressionUUID->"4de1aa9b-a0e5-4753-b0a9-ab22cabcea43"],
-Cell[129960, 3149, 1533, 35, 78, "Input",ExpressionUUID->"4dd70d5e-74fc-4847-aa52-1e3b1e6243f4"],
-Cell[131496, 3186, 165, 3, 38, "Text",ExpressionUUID->"3407460c-c659-4382-93ca-c8c5dffb11a9"],
-Cell[131664, 3191, 1553, 36, 78, "Input",ExpressionUUID->"65857bb5-0a29-4899-87fd-3add76772773"],
-Cell[133220, 3229, 1361, 33, 78, "Input",ExpressionUUID->"b173725a-ee62-324d-8a5e-0c2a591b4be3"],
-Cell[134584, 3264, 1361, 33, 78, "Input",ExpressionUUID->"e67a3992-5825-8546-867a-885243b2e716"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[135982, 3302, 289, 7, 48, "Subsubsection",ExpressionUUID->"8d26a702-86a5-478d-a63e-41d2fc83835f"],
-Cell[136274, 3311, 798, 21, 63, "Text",ExpressionUUID->"d11a38fa-1d61-43ab-a007-665d4cce7506"],
-Cell[137075, 3334, 1333, 27, 56, "Input",ExpressionUUID->"b4fe155e-35a7-4e9d-92ab-a6cebd055a5a"],
-Cell[138411, 3363, 951, 22, 56, "Input",ExpressionUUID->"da834576-328b-43da-a2d4-ab4e18f5e48c"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[139399, 3390, 289, 7, 48, "Subsubsection",ExpressionUUID->"db40d223-83bc-4d31-bef5-ee2ca2c1b7f7"],
-Cell[139691, 3399, 844, 22, 63, "Text",ExpressionUUID->"cec579e0-a96c-4560-883d-c9476449d54c"],
-Cell[140538, 3423, 1331, 27, 56, "Input",ExpressionUUID->"35fd6aea-457c-495a-9270-cfb11eee0f8c"],
-Cell[141872, 3452, 1348, 28, 56, "Input",ExpressionUUID->"1489b0a4-f67f-4df4-b93b-ae76af65760e"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[143257, 3485, 212, 4, 49, "Subsubsection",ExpressionUUID->"7b51b27d-86ba-466f-9e07-31efad1b1b85"],
-Cell[143472, 3491, 643, 15, 63, "Text",ExpressionUUID->"71724863-155c-4b9a-b903-456139e90ce4"],
-Cell[144118, 3508, 1120, 26, 56, "Input",ExpressionUUID->"919cc5ad-8264-4a60-be0b-0c331c7af613"],
-Cell[145241, 3536, 1096, 26, 56, "Input",ExpressionUUID->"9f2b7919-b606-4c84-b483-4f83b603d186"],
-Cell[146340, 3564, 1120, 26, 56, "Input",ExpressionUUID->"6faf6209-3363-4abd-88e4-6a8d5239115c"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[147497, 3595, 300, 7, 48, "Subsubsection",ExpressionUUID->"d4146341-d119-446a-bd81-d942be898a5b"],
-Cell[147800, 3604, 773, 19, 63, "Text",ExpressionUUID->"b43af3aa-2cae-4b82-a5ad-463511a95bb2"],
-Cell[148576, 3625, 1465, 33, 56, "Input",ExpressionUUID->"981a4bc5-304b-42f9-badc-d0e640b5ad63"],
-Cell[150044, 3660, 1391, 32, 56, "Input",ExpressionUUID->"69b1dce0-4b2b-44ee-8fb6-3310bd0c21bc"],
-Cell[151438, 3694, 1390, 32, 56, "Input",ExpressionUUID->"8b6095db-1cfd-4f7b-b254-d48343c90d92"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[152865, 3731, 421, 9, 50, "Subsubsection",ExpressionUUID->"c260b0ab-7923-4a43-94b2-a60f3fb55e85"],
-Cell[153289, 3742, 1092, 26, 89, "Text",ExpressionUUID->"4da76234-784a-4976-99ec-25db95f111c7"],
-Cell[154384, 3770, 1266, 29, 59, "Input",ExpressionUUID->"b1fcb425-9bfb-46f2-bba5-46801dee4d9e"],
-Cell[155653, 3801, 1189, 28, 59, "Input",ExpressionUUID->"07cd42bb-02cc-4c75-92b6-1d4d02c270ad"],
-Cell[156845, 3831, 1191, 28, 59, "Input",ExpressionUUID->"1f028b66-96d3-4e83-80ba-77718d460e26"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[158073, 3864, 325, 8, 50, "Subsubsection",ExpressionUUID->"fc811c97-cf65-44a5-ad12-29fcd3beb2eb"],
-Cell[158401, 3874, 1042, 25, 89, "Text",ExpressionUUID->"ba8a9599-f47c-4dab-a827-3d8f1851a2fd"],
-Cell[159446, 3901, 1341, 31, 59, "Input",ExpressionUUID->"e6c3b9d4-981e-432b-801d-9f78e97a7246"],
-Cell[160790, 3934, 1241, 30, 59, "Input",ExpressionUUID->"687a8ea0-70c6-409d-b278-8b816d7fd8e6"],
-Cell[162034, 3966, 1294, 31, 59, "Input",ExpressionUUID->"8fe3d5dc-4943-44b9-a604-1c4e33c2268d"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[163365, 4002, 511, 15, 51, "Subsubsection",ExpressionUUID->"d3f6a68e-4065-445a-80e4-4921927676e2"],
-Cell[163879, 4019, 1005, 23, 89, "Text",ExpressionUUID->"88276625-b1be-4d79-9d2e-0f7b73eb50d4"],
-Cell[164887, 4044, 1613, 38, 84, "Input",ExpressionUUID->"9e2acadb-7215-4795-bdd0-a1c5c6214afe"],
-Cell[166503, 4084, 1563, 37, 84, "Input",ExpressionUUID->"c5b2f9a1-e439-4b51-a004-ca0b23cf9198"],
-Cell[168069, 4123, 1564, 37, 84, "Input",ExpressionUUID->"683c6eb2-e32b-4448-aa97-cb3c16be88de"]
-}, Open  ]]
+Cell[127495, 3088, 157, 3, 48, "Subsubsection",ExpressionUUID->"22143b24-4e20-4413-a6ab-841320008ba6"],
+Cell[127655, 3093, 685, 16, 85, "Text",ExpressionUUID->"b4bc069c-6d32-4c89-9cd8-7339f96ce12b"],
+Cell[128343, 3111, 192, 3, 37, "Text",ExpressionUUID->"496c1129-12e6-4392-a55d-39eb6f7e7d23"],
+Cell[128538, 3116, 1551, 36, 166, "Input",ExpressionUUID->"4de1aa9b-a0e5-4753-b0a9-ab22cabcea43"],
+Cell[130092, 3154, 1533, 35, 144, "Input",ExpressionUUID->"4dd70d5e-74fc-4847-aa52-1e3b1e6243f4"],
+Cell[131628, 3191, 165, 3, 37, "Text",ExpressionUUID->"3407460c-c659-4382-93ca-c8c5dffb11a9"],
+Cell[131796, 3196, 1553, 36, 166, "Input",ExpressionUUID->"65857bb5-0a29-4899-87fd-3add76772773"],
+Cell[133352, 3234, 1361, 33, 144, "Input",ExpressionUUID->"b173725a-ee62-324d-8a5e-0c2a591b4be3"],
+Cell[134716, 3269, 1361, 33, 144, "Input",ExpressionUUID->"e67a3992-5825-8546-867a-885243b2e716"]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[169682, 4166, 191, 3, 40, "Subsection",ExpressionUUID->"2fb4a967-daa6-43c6-b865-d85cdc6ac61b"],
-Cell[169876, 4171, 1269, 32, 122, "Text",ExpressionUUID->"a956ad73-97ea-43a0-9216-4712fc2bdf70"],
+Cell[136114, 3307, 289, 7, 39, "Subsubsection",ExpressionUUID->"8d26a702-86a5-478d-a63e-41d2fc83835f"],
+Cell[136406, 3316, 798, 21, 85, "Text",ExpressionUUID->"d11a38fa-1d61-43ab-a007-665d4cce7506"],
+Cell[137207, 3339, 1333, 27, 77, "Input",ExpressionUUID->"b4fe155e-35a7-4e9d-92ab-a6cebd055a5a"],
+Cell[138543, 3368, 951, 22, 77, "Input",ExpressionUUID->"da834576-328b-43da-a2d4-ab4e18f5e48c"]
+}, Open  ]],
 Cell[CellGroupData[{
-Cell[171170, 4207, 158, 3, 49, "Subsubsection",ExpressionUUID->"873e9e40-0960-42f3-b6b4-2e3d728865c8"],
+Cell[139531, 3395, 289, 7, 48, "Subsubsection",ExpressionUUID->"db40d223-83bc-4d31-bef5-ee2ca2c1b7f7"],
+Cell[139823, 3404, 782, 20, 85, "Text",ExpressionUUID->"cec579e0-a96c-4560-883d-c9476449d54c"],
+Cell[140608, 3426, 1331, 27, 77, "Input",ExpressionUUID->"35fd6aea-457c-495a-9270-cfb11eee0f8c"],
+Cell[141942, 3455, 1348, 28, 77, "Input",ExpressionUUID->"1489b0a4-f67f-4df4-b93b-ae76af65760e"]
+}, Open  ]],
 Cell[CellGroupData[{
-Cell[171353, 4214, 2574, 55, 381, "Input",ExpressionUUID->"0071c621-bbd6-4f98-a9a7-11c2f878c47c"],
+Cell[143327, 3488, 212, 4, 48, "Subsubsection",ExpressionUUID->"7b51b27d-86ba-466f-9e07-31efad1b1b85"],
+Cell[143542, 3494, 643, 15, 61, "Text",ExpressionUUID->"71724863-155c-4b9a-b903-456139e90ce4"],
+Cell[144188, 3511, 1120, 26, 121, "Input",ExpressionUUID->"919cc5ad-8264-4a60-be0b-0c331c7af613"],
+Cell[145311, 3539, 1096, 26, 121, "Input",ExpressionUUID->"9f2b7919-b606-4c84-b483-4f83b603d186"],
+Cell[146410, 3567, 1120, 26, 121, "Input",ExpressionUUID->"6faf6209-3363-4abd-88e4-6a8d5239115c"]
+}, Open  ]],
 Cell[CellGroupData[{
-Cell[173952, 4273, 318, 6, 25, "Print",ExpressionUUID->"14ee0a8d-1fc8-41df-9788-b189adc92b75"],
-Cell[174273, 4281, 320, 6, 25, "Print",ExpressionUUID->"56bc0aad-7a23-4b03-a49e-e64d4a02e469"],
-Cell[174596, 4289, 318, 6, 25, "Print",ExpressionUUID->"4d97b8cd-a9be-4fb3-a80b-ab6102a1aca0"],
-Cell[174917, 4297, 318, 6, 25, "Print",ExpressionUUID->"c71d56f3-8764-4fed-a11c-7bec9fff5264"],
-Cell[175238, 4305, 317, 6, 25, "Print",ExpressionUUID->"0faff69d-77e7-43e8-801a-5af689b350bc"],
-Cell[175558, 4313, 318, 6, 25, "Print",ExpressionUUID->"7130b35a-4b72-4d1d-b768-193e89b27255"],
-Cell[175879, 4321, 317, 6, 25, "Print",ExpressionUUID->"cd68b01b-a0b2-4430-a3b7-331b4ce83294"],
-Cell[176199, 4329, 318, 6, 25, "Print",ExpressionUUID->"871bdcab-b164-4f4c-a9ac-25bfa036a8c4"],
-Cell[176520, 4337, 319, 6, 25, "Print",ExpressionUUID->"03d0a863-d966-4e3a-ba6b-0186e3211a0b"],
-Cell[176842, 4345, 321, 6, 25, "Print",ExpressionUUID->"088b977f-5b4d-4872-888a-d09364aebafb"],
-Cell[177166, 4353, 319, 6, 25, "Print",ExpressionUUID->"1fa6f9d1-c963-456e-ae67-0728353e993e"],
-Cell[177488, 4361, 319, 6, 25, "Print",ExpressionUUID->"de3ac3c8-5534-4a55-bc1a-18cb3888bed0"],
-Cell[177810, 4369, 321, 6, 25, "Print",ExpressionUUID->"4e46a085-1707-4dca-8372-7ff6ec62e161"],
-Cell[178134, 4377, 321, 6, 25, "Print",ExpressionUUID->"0fded57e-c5b9-4de5-be46-89c346c0c442"],
-Cell[178458, 4385, 319, 6, 25, "Print",ExpressionUUID->"3cd2325e-4b65-462f-943c-9714aef80f25"],
-Cell[178780, 4393, 319, 6, 25, "Print",ExpressionUUID->"e2b81774-6424-4646-b9e2-be31f5705c79"],
-Cell[179102, 4401, 319, 6, 25, "Print",ExpressionUUID->"da557cca-2ada-4e8a-92ec-3c75ecc468be"],
-Cell[179424, 4409, 319, 6, 25, "Print",ExpressionUUID->"b0504a3e-6e12-4575-8f1f-8b5799ae058b"],
-Cell[179746, 4417, 319, 6, 25, "Print",ExpressionUUID->"45ce1b99-169a-49e0-a652-2871922b262b"],
-Cell[180068, 4425, 321, 6, 25, "Print",ExpressionUUID->"bbd00666-ddc0-4d0c-9888-5f2bd9323be8"],
-Cell[180392, 4433, 319, 6, 25, "Print",ExpressionUUID->"276cf600-1574-43ab-a4aa-bc79b7ebfd29"],
-Cell[180714, 4441, 318, 6, 25, "Print",ExpressionUUID->"a50e267b-1653-412e-9b46-393c0e054bc5"],
-Cell[181035, 4449, 321, 6, 25, "Print",ExpressionUUID->"63324543-891a-48c7-a79a-7efabe0a8e0f"],
-Cell[181359, 4457, 318, 6, 25, "Print",ExpressionUUID->"c1a0f9d9-1b97-4ead-94a8-1b6bf72d57ff"],
-Cell[181680, 4465, 319, 6, 25, "Print",ExpressionUUID->"fab32792-cb36-4a84-a416-2c978415e056"],
-Cell[182002, 4473, 319, 6, 25, "Print",ExpressionUUID->"122e4ffc-81d6-4317-a118-2699d25e7030"],
-Cell[182324, 4481, 318, 6, 25, "Print",ExpressionUUID->"91d5e940-fe15-4508-afed-e3251eb148ca"],
-Cell[182645, 4489, 319, 6, 25, "Print",ExpressionUUID->"f7e46271-12ac-40ea-8803-1fb28ff1664e"],
-Cell[182967, 4497, 318, 6, 25, "Print",ExpressionUUID->"9b97f4ca-d7e2-4f7b-b46a-ca0c5abb4fa0"],
-Cell[183288, 4505, 318, 6, 25, "Print",ExpressionUUID->"0d7d15db-44a2-4102-b7b0-c672e18a07b1"],
-Cell[183609, 4513, 321, 6, 25, "Print",ExpressionUUID->"a833cedf-be9c-4f79-831d-0bc375b167e2"],
-Cell[183933, 4521, 319, 6, 25, "Print",ExpressionUUID->"61632d0c-e97c-4e70-ba71-14126a375423"],
-Cell[184255, 4529, 319, 6, 25, "Print",ExpressionUUID->"39d81cb6-d724-4a75-90b9-3b6334b143a0"],
-Cell[184577, 4537, 319, 6, 25, "Print",ExpressionUUID->"7db651c7-e397-456b-a992-8b885c606ad5"],
-Cell[184899, 4545, 321, 6, 25, "Print",ExpressionUUID->"89daf759-187b-48c3-bfc1-e4bd26e1d5ad"],
-Cell[185223, 4553, 319, 6, 25, "Print",ExpressionUUID->"8d4051f3-3603-4e24-9196-c6191bcecf02"],
-Cell[185545, 4561, 319, 6, 25, "Print",ExpressionUUID->"f4a6626b-84f5-42fc-ad9a-ac986d679267"],
-Cell[185867, 4569, 321, 6, 25, "Print",ExpressionUUID->"a095b627-aeb1-41db-baa0-73d552b0cc4d"],
-Cell[186191, 4577, 318, 6, 25, "Print",ExpressionUUID->"7ecd2bdc-1ee8-485f-96de-42a7d534ef27"],
-Cell[186512, 4585, 318, 6, 25, "Print",ExpressionUUID->"69a8a617-d580-4cc5-8534-e11ef7f68c1f"],
-Cell[186833, 4593, 319, 6, 25, "Print",ExpressionUUID->"0306ae00-c896-4c2b-a5cb-2f9fbc817720"],
-Cell[187155, 4601, 319, 6, 25, "Print",ExpressionUUID->"06ecc18f-3855-44dc-a1a9-b0366bd90145"],
-Cell[187477, 4609, 321, 6, 25, "Print",ExpressionUUID->"df900948-fc76-4d1b-be56-a17bb8c90d93"],
-Cell[187801, 4617, 319, 6, 25, "Print",ExpressionUUID->"406ee03e-8751-4edf-8149-f9d6174e058c"],
-Cell[188123, 4625, 319, 6, 25, "Print",ExpressionUUID->"f68abea6-5e72-4221-a894-1da119e4751b"],
-Cell[188445, 4633, 319, 6, 25, "Print",ExpressionUUID->"6b831ce8-85cf-4a69-a298-b9fea3fafcfa"],
-Cell[188767, 4641, 319, 6, 25, "Print",ExpressionUUID->"bde0c91a-cc4b-42f3-9f71-42d058ee00b8"]
+Cell[147567, 3598, 300, 7, 48, "Subsubsection",ExpressionUUID->"d4146341-d119-446a-bd81-d942be898a5b"],
+Cell[147870, 3607, 773, 19, 61, "Text",ExpressionUUID->"b43af3aa-2cae-4b82-a5ad-463511a95bb2"],
+Cell[148646, 3628, 1465, 33, 144, "Input",ExpressionUUID->"981a4bc5-304b-42f9-badc-d0e640b5ad63"],
+Cell[150114, 3663, 1391, 32, 144, "Input",ExpressionUUID->"69b1dce0-4b2b-44ee-8fb6-3310bd0c21bc"],
+Cell[151508, 3697, 1390, 32, 144, "Input",ExpressionUUID->"8b6095db-1cfd-4f7b-b254-d48343c90d92"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[152935, 3734, 421, 9, 48, "Subsubsection",ExpressionUUID->"c260b0ab-7923-4a43-94b2-a60f3fb55e85"],
+Cell[153359, 3745, 1030, 24, 109, "Text",ExpressionUUID->"4da76234-784a-4976-99ec-25db95f111c7"],
+Cell[154392, 3771, 1266, 29, 131, "Input",ExpressionUUID->"b1fcb425-9bfb-46f2-bba5-46801dee4d9e"],
+Cell[155661, 3802, 1189, 28, 131, "Input",ExpressionUUID->"07cd42bb-02cc-4c75-92b6-1d4d02c270ad"],
+Cell[156853, 3832, 1191, 28, 131, "Input",ExpressionUUID->"1f028b66-96d3-4e83-80ba-77718d460e26"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[158081, 3865, 325, 8, 48, "Subsubsection",ExpressionUUID->"fc811c97-cf65-44a5-ad12-29fcd3beb2eb"],
+Cell[158409, 3875, 980, 23, 109, "Text",ExpressionUUID->"ba8a9599-f47c-4dab-a827-3d8f1851a2fd"],
+Cell[159392, 3900, 1341, 31, 156, "Input",ExpressionUUID->"e6c3b9d4-981e-432b-801d-9f78e97a7246"],
+Cell[160736, 3933, 1241, 30, 156, "Input",ExpressionUUID->"687a8ea0-70c6-409d-b278-8b816d7fd8e6"],
+Cell[161980, 3965, 1294, 31, 156, "Input",ExpressionUUID->"8fe3d5dc-4943-44b9-a604-1c4e33c2268d"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[163311, 4001, 511, 15, 48, "Subsubsection",ExpressionUUID->"d3f6a68e-4065-445a-80e4-4921927676e2"],
+Cell[163825, 4018, 974, 22, 85, "Text",ExpressionUUID->"88276625-b1be-4d79-9d2e-0f7b73eb50d4"],
+Cell[164802, 4042, 1611, 38, 178, "Input",ExpressionUUID->"9e2acadb-7215-4795-bdd0-a1c5c6214afe"],
+Cell[166416, 4082, 1561, 37, 178, "Input",ExpressionUUID->"c5b2f9a1-e439-4b51-a004-ca0b23cf9198"],
+Cell[167980, 4121, 1562, 37, 178, "Input",ExpressionUUID->"683c6eb2-e32b-4448-aa97-cb3c16be88de"]
+}, Open  ]]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[169591, 4164, 191, 3, 58, "Subsection",ExpressionUUID->"2fb4a967-daa6-43c6-b865-d85cdc6ac61b"],
+Cell[169785, 4169, 1269, 32, 114, "Text",ExpressionUUID->"a956ad73-97ea-43a0-9216-4712fc2bdf70"],
+Cell[CellGroupData[{
+Cell[171079, 4205, 158, 3, 48, "Subsubsection",ExpressionUUID->"873e9e40-0960-42f3-b6b4-2e3d728865c8"],
+Cell[CellGroupData[{
+Cell[171262, 4212, 2574, 55, 352, "Input",ExpressionUUID->"0071c621-bbd6-4f98-a9a7-11c2f878c47c"],
+Cell[CellGroupData[{
+Cell[173861, 4271, 318, 6, 25, "Print",ExpressionUUID->"14ee0a8d-1fc8-41df-9788-b189adc92b75"],
+Cell[174182, 4279, 320, 6, 25, "Print",ExpressionUUID->"56bc0aad-7a23-4b03-a49e-e64d4a02e469"],
+Cell[174505, 4287, 318, 6, 25, "Print",ExpressionUUID->"4d97b8cd-a9be-4fb3-a80b-ab6102a1aca0"],
+Cell[174826, 4295, 318, 6, 25, "Print",ExpressionUUID->"c71d56f3-8764-4fed-a11c-7bec9fff5264"],
+Cell[175147, 4303, 317, 6, 25, "Print",ExpressionUUID->"0faff69d-77e7-43e8-801a-5af689b350bc"],
+Cell[175467, 4311, 318, 6, 25, "Print",ExpressionUUID->"7130b35a-4b72-4d1d-b768-193e89b27255"],
+Cell[175788, 4319, 317, 6, 25, "Print",ExpressionUUID->"cd68b01b-a0b2-4430-a3b7-331b4ce83294"],
+Cell[176108, 4327, 318, 6, 25, "Print",ExpressionUUID->"871bdcab-b164-4f4c-a9ac-25bfa036a8c4"],
+Cell[176429, 4335, 319, 6, 25, "Print",ExpressionUUID->"03d0a863-d966-4e3a-ba6b-0186e3211a0b"],
+Cell[176751, 4343, 321, 6, 25, "Print",ExpressionUUID->"088b977f-5b4d-4872-888a-d09364aebafb"],
+Cell[177075, 4351, 319, 6, 25, "Print",ExpressionUUID->"1fa6f9d1-c963-456e-ae67-0728353e993e"],
+Cell[177397, 4359, 319, 6, 25, "Print",ExpressionUUID->"de3ac3c8-5534-4a55-bc1a-18cb3888bed0"],
+Cell[177719, 4367, 321, 6, 25, "Print",ExpressionUUID->"4e46a085-1707-4dca-8372-7ff6ec62e161"],
+Cell[178043, 4375, 321, 6, 25, "Print",ExpressionUUID->"0fded57e-c5b9-4de5-be46-89c346c0c442"],
+Cell[178367, 4383, 319, 6, 25, "Print",ExpressionUUID->"3cd2325e-4b65-462f-943c-9714aef80f25"],
+Cell[178689, 4391, 319, 6, 25, "Print",ExpressionUUID->"e2b81774-6424-4646-b9e2-be31f5705c79"],
+Cell[179011, 4399, 319, 6, 25, "Print",ExpressionUUID->"da557cca-2ada-4e8a-92ec-3c75ecc468be"],
+Cell[179333, 4407, 319, 6, 25, "Print",ExpressionUUID->"b0504a3e-6e12-4575-8f1f-8b5799ae058b"],
+Cell[179655, 4415, 319, 6, 25, "Print",ExpressionUUID->"45ce1b99-169a-49e0-a652-2871922b262b"],
+Cell[179977, 4423, 321, 6, 25, "Print",ExpressionUUID->"bbd00666-ddc0-4d0c-9888-5f2bd9323be8"],
+Cell[180301, 4431, 319, 6, 25, "Print",ExpressionUUID->"276cf600-1574-43ab-a4aa-bc79b7ebfd29"],
+Cell[180623, 4439, 318, 6, 25, "Print",ExpressionUUID->"a50e267b-1653-412e-9b46-393c0e054bc5"],
+Cell[180944, 4447, 321, 6, 25, "Print",ExpressionUUID->"63324543-891a-48c7-a79a-7efabe0a8e0f"],
+Cell[181268, 4455, 318, 6, 25, "Print",ExpressionUUID->"c1a0f9d9-1b97-4ead-94a8-1b6bf72d57ff"],
+Cell[181589, 4463, 319, 6, 25, "Print",ExpressionUUID->"fab32792-cb36-4a84-a416-2c978415e056"],
+Cell[181911, 4471, 319, 6, 25, "Print",ExpressionUUID->"122e4ffc-81d6-4317-a118-2699d25e7030"],
+Cell[182233, 4479, 318, 6, 25, "Print",ExpressionUUID->"91d5e940-fe15-4508-afed-e3251eb148ca"],
+Cell[182554, 4487, 319, 6, 25, "Print",ExpressionUUID->"f7e46271-12ac-40ea-8803-1fb28ff1664e"],
+Cell[182876, 4495, 318, 6, 25, "Print",ExpressionUUID->"9b97f4ca-d7e2-4f7b-b46a-ca0c5abb4fa0"],
+Cell[183197, 4503, 318, 6, 25, "Print",ExpressionUUID->"0d7d15db-44a2-4102-b7b0-c672e18a07b1"],
+Cell[183518, 4511, 321, 6, 25, "Print",ExpressionUUID->"a833cedf-be9c-4f79-831d-0bc375b167e2"],
+Cell[183842, 4519, 319, 6, 25, "Print",ExpressionUUID->"61632d0c-e97c-4e70-ba71-14126a375423"],
+Cell[184164, 4527, 319, 6, 25, "Print",ExpressionUUID->"39d81cb6-d724-4a75-90b9-3b6334b143a0"],
+Cell[184486, 4535, 319, 6, 25, "Print",ExpressionUUID->"7db651c7-e397-456b-a992-8b885c606ad5"],
+Cell[184808, 4543, 321, 6, 25, "Print",ExpressionUUID->"89daf759-187b-48c3-bfc1-e4bd26e1d5ad"],
+Cell[185132, 4551, 319, 6, 25, "Print",ExpressionUUID->"8d4051f3-3603-4e24-9196-c6191bcecf02"],
+Cell[185454, 4559, 319, 6, 25, "Print",ExpressionUUID->"f4a6626b-84f5-42fc-ad9a-ac986d679267"],
+Cell[185776, 4567, 321, 6, 25, "Print",ExpressionUUID->"a095b627-aeb1-41db-baa0-73d552b0cc4d"],
+Cell[186100, 4575, 318, 6, 25, "Print",ExpressionUUID->"7ecd2bdc-1ee8-485f-96de-42a7d534ef27"],
+Cell[186421, 4583, 318, 6, 25, "Print",ExpressionUUID->"69a8a617-d580-4cc5-8534-e11ef7f68c1f"],
+Cell[186742, 4591, 319, 6, 25, "Print",ExpressionUUID->"0306ae00-c896-4c2b-a5cb-2f9fbc817720"],
+Cell[187064, 4599, 319, 6, 25, "Print",ExpressionUUID->"06ecc18f-3855-44dc-a1a9-b0366bd90145"],
+Cell[187386, 4607, 321, 6, 25, "Print",ExpressionUUID->"df900948-fc76-4d1b-be56-a17bb8c90d93"],
+Cell[187710, 4615, 319, 6, 25, "Print",ExpressionUUID->"406ee03e-8751-4edf-8149-f9d6174e058c"],
+Cell[188032, 4623, 319, 6, 25, "Print",ExpressionUUID->"f68abea6-5e72-4221-a894-1da119e4751b"],
+Cell[188354, 4631, 319, 6, 25, "Print",ExpressionUUID->"6b831ce8-85cf-4a69-a298-b9fea3fafcfa"],
+Cell[188676, 4639, 319, 6, 25, "Print",ExpressionUUID->"bde0c91a-cc4b-42f3-9f71-42d058ee00b8"]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[189147, 4654, 160, 3, 49, "Subsubsection",ExpressionUUID->"f03b6cd1-a49c-4d9f-8b03-0a537a85ad34"],
+Cell[189056, 4652, 160, 3, 49, "Subsubsection",ExpressionUUID->"f03b6cd1-a49c-4d9f-8b03-0a537a85ad34"],
 Cell[CellGroupData[{
-Cell[189332, 4661, 1926, 46, 358, "Input",ExpressionUUID->"cf493844-a84e-4dfa-81e8-ea5de275e2ac"],
+Cell[189241, 4659, 1926, 46, 358, "Input",ExpressionUUID->"cf493844-a84e-4dfa-81e8-ea5de275e2ac"],
 Cell[CellGroupData[{
-Cell[191283, 4711, 198, 4, 25, "Print",ExpressionUUID->"c5b5dc1e-7a49-4adb-9c36-9eeebd73773a"],
-Cell[191484, 4717, 200, 4, 25, "Print",ExpressionUUID->"060fed66-0143-4c9f-bdb4-0bfe97a2da78"],
-Cell[191687, 4723, 198, 4, 25, "Print",ExpressionUUID->"07abd5cc-939e-4e0b-b88f-4721b55999f1"],
-Cell[191888, 4729, 198, 4, 25, "Print",ExpressionUUID->"153fe3e6-8ac9-4895-b819-442ad1499b9b"],
-Cell[192089, 4735, 198, 4, 25, "Print",ExpressionUUID->"1c694cb2-1edc-4da3-b6bf-f1cc3d79d159"],
-Cell[192290, 4741, 198, 4, 25, "Print",ExpressionUUID->"8c47e9cb-e216-42d9-b591-f179d4242056"],
-Cell[192491, 4747, 200, 4, 25, "Print",ExpressionUUID->"88fcfc98-ea19-42c4-bd9d-0a5c196dc2b2"],
-Cell[192694, 4753, 198, 4, 25, "Print",ExpressionUUID->"45ca3fa1-bb31-4784-b532-cfda5865c49d"],
-Cell[192895, 4759, 199, 4, 25, "Print",ExpressionUUID->"88c7d300-26e1-4374-9195-ab8e41402fe5"],
-Cell[193097, 4765, 199, 4, 25, "Print",ExpressionUUID->"adc02e62-6f94-4ed6-812b-49ed3fe3ef34"],
-Cell[193299, 4771, 199, 4, 25, "Print",ExpressionUUID->"449d4b9f-a2ae-458b-b82f-c98eb71d4128"],
-Cell[193501, 4777, 199, 4, 25, "Print",ExpressionUUID->"1109e18f-e0b7-4bec-983b-f1988b9f4e9e"],
-Cell[193703, 4783, 199, 4, 25, "Print",ExpressionUUID->"c6f8f3b1-9489-4592-8199-89b939468b21"],
-Cell[193905, 4789, 199, 4, 25, "Print",ExpressionUUID->"eccae9b8-fb42-4b35-998c-ac0f6975e07c"],
-Cell[194107, 4795, 199, 4, 25, "Print",ExpressionUUID->"b1b9d7c4-b209-4c08-b3e5-1bc64b0bdd6a"],
-Cell[194309, 4801, 199, 4, 25, "Print",ExpressionUUID->"dfa87c64-90a1-4e3e-b220-8826f05bb855"],
-Cell[194511, 4807, 201, 4, 25, "Print",ExpressionUUID->"ff1c30b6-fdcf-420d-80ba-781c6865e260"],
-Cell[194715, 4813, 199, 4, 25, "Print",ExpressionUUID->"27eae6cc-581d-4858-9570-06c969011b13"],
-Cell[194917, 4819, 201, 4, 25, "Print",ExpressionUUID->"79fab8cc-19ab-47dd-b4a0-66bf71854016"],
-Cell[195121, 4825, 199, 4, 25, "Print",ExpressionUUID->"3ae68728-c0de-4cc9-99d8-e6eccdd5d717"],
-Cell[195323, 4831, 201, 4, 25, "Print",ExpressionUUID->"b8cdb15d-bd62-42b7-8ab8-0ed37c0c8763"],
-Cell[195527, 4837, 199, 4, 25, "Print",ExpressionUUID->"e90eeeb1-92f0-4c35-aff3-b4a9c87da6ce"],
-Cell[195729, 4843, 199, 4, 25, "Print",ExpressionUUID->"cdbf3cc9-e084-49ef-a718-03e6b6b64658"],
-Cell[195931, 4849, 199, 4, 25, "Print",ExpressionUUID->"9a543198-c3d2-4809-9e96-30a0c652ee2c"],
-Cell[196133, 4855, 201, 4, 25, "Print",ExpressionUUID->"2d6c405c-34be-487c-a732-cbcdb2e88938"],
-Cell[196337, 4861, 201, 4, 25, "Print",ExpressionUUID->"bf4493f2-aa67-4921-bbd4-95d5d41d6899"],
-Cell[196541, 4867, 199, 4, 25, "Print",ExpressionUUID->"054ae59f-56c9-4b83-a827-9fbd347896ed"],
-Cell[196743, 4873, 199, 4, 25, "Print",ExpressionUUID->"41657ef1-ab20-4839-a89b-8b62c2bd57ac"],
-Cell[196945, 4879, 199, 4, 25, "Print",ExpressionUUID->"121e65c2-5d87-47ef-b9b2-242a9dd1e8c9"],
-Cell[197147, 4885, 199, 4, 25, "Print",ExpressionUUID->"22188474-f152-453a-855f-ba1ca6c3ad3e"],
-Cell[197349, 4891, 201, 4, 25, "Print",ExpressionUUID->"9f1f505d-ca0c-4dd6-8347-dadaf6c8d04f"],
-Cell[197553, 4897, 201, 4, 25, "Print",ExpressionUUID->"3b35a460-4325-4918-883e-4fc0a4d52129"],
-Cell[197757, 4903, 199, 4, 25, "Print",ExpressionUUID->"43dd121d-ff45-422a-b6c8-9affd72a2fef"],
-Cell[197959, 4909, 201, 4, 25, "Print",ExpressionUUID->"f72534f2-9a10-4ace-ac3d-401c8fb5c37b"],
-Cell[198163, 4915, 201, 4, 25, "Print",ExpressionUUID->"f2fcc307-53b1-4479-808d-529e282765aa"],
-Cell[198367, 4921, 201, 4, 25, "Print",ExpressionUUID->"9e098dad-7892-436f-aa78-c56dc07ede97"],
-Cell[198571, 4927, 201, 4, 25, "Print",ExpressionUUID->"07455b67-3d6a-4bd1-92a9-c73215ca505a"],
-Cell[198775, 4933, 199, 4, 25, "Print",ExpressionUUID->"0ffcc929-dc2a-4bd1-9a37-e28663b3ab4b"],
-Cell[198977, 4939, 199, 4, 25, "Print",ExpressionUUID->"b544bda8-153d-4c29-9e96-100bac875f1e"],
-Cell[199179, 4945, 201, 4, 25, "Print",ExpressionUUID->"f1d35551-dddf-42dc-baaa-c15108f8a255"],
-Cell[199383, 4951, 198, 4, 25, "Print",ExpressionUUID->"40b508b0-eaff-4945-acd9-7ac57b551b9f"],
-Cell[199584, 4957, 199, 4, 25, "Print",ExpressionUUID->"0545a95e-674a-4aeb-9e3b-7224394a1081"],
-Cell[199786, 4963, 201, 4, 25, "Print",ExpressionUUID->"b6de5818-dce8-445a-82c5-aa7bc0f79dff"],
-Cell[199990, 4969, 198, 4, 25, "Print",ExpressionUUID->"6221c72a-071e-46bd-b8d2-c30607c8b4d2"],
-Cell[200191, 4975, 198, 4, 25, "Print",ExpressionUUID->"66155384-14ea-4737-8e00-676991c6b754"],
-Cell[200392, 4981, 199, 4, 25, "Print",ExpressionUUID->"2252c55f-9572-4d83-9c12-7af99ad46644"],
-Cell[200594, 4987, 199, 4, 25, "Print",ExpressionUUID->"438b69cc-1a39-4c1a-9633-edf63b87edb4"],
-Cell[200796, 4993, 174, 4, 77, "Print",ExpressionUUID->"f5e7e907-17a6-434b-97b4-449792f39e92"],
-Cell[200973, 4999, 176, 4, 77, "Print",ExpressionUUID->"c02f216e-79a8-4b53-becd-0c00ec4b8c41"],
-Cell[201152, 5005, 174, 4, 77, "Print",ExpressionUUID->"3b46a7bc-24e0-47f9-9295-c39b079a2529"],
-Cell[201329, 5011, 176, 4, 77, "Print",ExpressionUUID->"60b8ac53-237f-4eae-90f2-18e8bbbc7b79"],
-Cell[201508, 5017, 174, 4, 77, "Print",ExpressionUUID->"6a0e4594-6d40-4ca3-bcb3-8a780fee3445"],
-Cell[201685, 5023, 174, 4, 77, "Print",ExpressionUUID->"847855c6-157a-4944-9381-1609ecb3010d"],
-Cell[201862, 5029, 174, 4, 77, "Print",ExpressionUUID->"5b8d8877-68e0-4c1f-b432-869a6ba630a0"],
-Cell[202039, 5035, 174, 4, 77, "Print",ExpressionUUID->"466c8858-a401-4888-b107-ce4d35ee85a6"],
-Cell[202216, 5041, 175, 4, 77, "Print",ExpressionUUID->"68416fc0-e13b-4e2d-b9c4-34bfa8ccdd7a"],
-Cell[202394, 5047, 177, 4, 77, "Print",ExpressionUUID->"e8c24090-3901-4e66-95b8-d04366254b4e"],
-Cell[202574, 5053, 177, 4, 77, "Print",ExpressionUUID->"d333cc16-c0b3-4d52-a035-f11b0f83cf32"],
-Cell[202754, 5059, 175, 4, 77, "Print",ExpressionUUID->"379c8ddd-841d-46c0-b719-9d33f1957bd1"],
-Cell[202932, 5065, 174, 4, 77, "Print",ExpressionUUID->"a1b5491a-ae07-4b61-9719-49b73db33192"],
-Cell[203109, 5071, 175, 4, 77, "Print",ExpressionUUID->"8723c5cf-9175-4dbf-a09e-42cbd5067df9"],
-Cell[203287, 5077, 175, 4, 77, "Print",ExpressionUUID->"7a119cb1-a9c8-4bf3-983c-60bb5d882c7c"],
-Cell[203465, 5083, 174, 4, 77, "Print",ExpressionUUID->"0438a27e-b3af-41e3-a378-b9115071d6db"],
-Cell[203642, 5089, 177, 4, 77, "Print",ExpressionUUID->"a3b5652d-b12b-4b22-8bda-4ecd87807880"],
-Cell[203822, 5095, 174, 4, 77, "Print",ExpressionUUID->"4387bbbf-4b92-43c1-a54a-bb5ecff983b5"],
-Cell[203999, 5101, 175, 4, 77, "Print",ExpressionUUID->"424881d8-a5ae-41fb-9cbe-730e3c0a2bb0"],
-Cell[204177, 5107, 175, 4, 77, "Print",ExpressionUUID->"d8b112d2-277f-45cb-acae-bfcd9d460ecf"],
-Cell[204355, 5113, 175, 4, 77, "Print",ExpressionUUID->"46d82a89-a0f1-4a6e-84ee-ef5628194ada"],
-Cell[204533, 5119, 175, 4, 77, "Print",ExpressionUUID->"8935cb61-62f4-4825-9de0-1ee34b19725e"],
-Cell[204711, 5125, 175, 4, 77, "Print",ExpressionUUID->"176c9180-582a-475f-952d-4d043dc4693b"],
-Cell[204889, 5131, 175, 4, 77, "Print",ExpressionUUID->"ae2a17c4-3bb9-4cb3-901d-672400d279b0"],
-Cell[205067, 5137, 177, 4, 77, "Print",ExpressionUUID->"47c7ba5d-69d6-4459-bb63-7eeb84d0cc15"],
-Cell[205247, 5143, 173, 4, 77, "Print",ExpressionUUID->"17d7c441-bd99-4d55-86eb-4862a3aa8e84"],
-Cell[205423, 5149, 177, 4, 77, "Print",ExpressionUUID->"9343ac10-a007-4cdf-b232-e6813c80dfff"],
-Cell[205603, 5155, 175, 4, 77, "Print",ExpressionUUID->"3b72fe81-8347-48fc-a4df-9be0bb7457b3"],
-Cell[205781, 5161, 175, 4, 77, "Print",ExpressionUUID->"fec764f7-d5cb-4e41-ac37-877124dc01ed"],
-Cell[205959, 5167, 175, 4, 77, "Print",ExpressionUUID->"44341dbf-dfd8-4b26-92b0-e64a33c029cf"],
-Cell[206137, 5173, 175, 4, 77, "Print",ExpressionUUID->"8621872a-c0ce-402b-8b44-129d5571be77"],
-Cell[206315, 5179, 174, 4, 77, "Print",ExpressionUUID->"35bc48f8-26a6-43bf-a980-1cd915790d0e"],
-Cell[206492, 5185, 175, 4, 77, "Print",ExpressionUUID->"1afb2d14-8699-4b84-a0cc-67814f3b7f0d"],
-Cell[206670, 5191, 175, 4, 77, "Print",ExpressionUUID->"e518f44b-1671-4c5f-9b01-6ac5a8b02fa5"],
-Cell[206848, 5197, 174, 4, 77, "Print",ExpressionUUID->"3bd7dc34-3439-463a-aeca-b5826ab262d2"],
-Cell[207025, 5203, 175, 4, 77, "Print",ExpressionUUID->"6f0ce850-04be-43ac-a000-a8e2d99214ca"],
-Cell[207203, 5209, 175, 4, 77, "Print",ExpressionUUID->"c982f935-cf77-4eed-856a-095607853357"],
-Cell[207381, 5215, 175, 4, 77, "Print",ExpressionUUID->"69ee4881-5725-49cf-bee5-c9cb306a66b7"],
-Cell[207559, 5221, 177, 4, 77, "Print",ExpressionUUID->"6e84f5bc-6c6c-40f2-aae4-028bcce649dd"],
-Cell[207739, 5227, 175, 4, 77, "Print",ExpressionUUID->"68f4a1c9-d47e-4c02-931e-6b09eee55c72"],
-Cell[207917, 5233, 177, 4, 77, "Print",ExpressionUUID->"85f186c3-06b0-4034-90e8-a2a0ca9c9cd4"],
-Cell[208097, 5239, 177, 4, 77, "Print",ExpressionUUID->"d4ac599e-686d-491c-9c65-91f7ba8f4c5b"],
-Cell[208277, 5245, 175, 4, 77, "Print",ExpressionUUID->"2259e8a5-51da-4e16-8d66-6db6785d2f44"],
-Cell[208455, 5251, 175, 4, 77, "Print",ExpressionUUID->"6e6f7f03-be91-4bd4-ad8e-0efa6ed95fe5"],
-Cell[208633, 5257, 175, 4, 77, "Print",ExpressionUUID->"163e8b59-b650-4f06-8f69-31f95cf60883"],
-Cell[208811, 5263, 175, 4, 77, "Print",ExpressionUUID->"f91018f8-e572-4ad5-a49c-100139ffe9d4"],
-Cell[208989, 5269, 175, 4, 77, "Print",ExpressionUUID->"77a0ab60-b198-4afe-b0ff-2cde2b87db2c"],
-Cell[209167, 5275, 174, 4, 77, "Print",ExpressionUUID->"70df2d90-c3e8-4775-bd9c-28e8de94e374"],
-Cell[209344, 5281, 174, 4, 77, "Print",ExpressionUUID->"9d9e0200-c495-4719-9ea6-ba48eda4af7d"],
-Cell[209521, 5287, 174, 4, 77, "Print",ExpressionUUID->"4785ae0a-d8ae-492b-9bf9-cda425b0b011"],
-Cell[209698, 5293, 174, 4, 77, "Print",ExpressionUUID->"13108136-c303-4bf3-b8e8-511a67410fff"],
-Cell[209875, 5299, 174, 4, 77, "Print",ExpressionUUID->"38a852da-0a04-4621-93eb-df7315e30f1c"],
-Cell[210052, 5305, 174, 4, 77, "Print",ExpressionUUID->"ba5fe259-2013-4bbb-a9e8-8048848db0b5"],
-Cell[210229, 5311, 174, 4, 77, "Print",ExpressionUUID->"4f013174-e794-4719-adc5-160049763b7a"],
-Cell[210406, 5317, 174, 4, 77, "Print",ExpressionUUID->"d2ef1ba8-f373-4a11-acca-4d3a51e69084"],
-Cell[210583, 5323, 175, 4, 77, "Print",ExpressionUUID->"b198af96-c8df-46c8-88bd-cdf5285642cb"],
-Cell[210761, 5329, 175, 4, 77, "Print",ExpressionUUID->"fb0b58cb-0660-4827-b78e-7ca3110c14fa"],
-Cell[210939, 5335, 175, 4, 77, "Print",ExpressionUUID->"166ce08d-acea-415d-9a72-688b0af44a76"],
-Cell[211117, 5341, 174, 4, 77, "Print",ExpressionUUID->"59d9ae9d-e1be-4206-9240-370006ea4652"],
-Cell[211294, 5347, 175, 4, 77, "Print",ExpressionUUID->"d9879f24-84a2-43bc-8fe5-30fc78f50680"],
-Cell[211472, 5353, 175, 4, 77, "Print",ExpressionUUID->"a89b8736-50f7-4cd2-b621-90cc46b95261"],
-Cell[211650, 5359, 175, 4, 77, "Print",ExpressionUUID->"4704cb3b-ed0c-4bf2-9363-a467da372110"],
-Cell[211828, 5365, 177, 4, 77, "Print",ExpressionUUID->"e1b2bbcf-59cd-4856-90c5-6ed1e22dfe84"],
-Cell[212008, 5371, 177, 4, 77, "Print",ExpressionUUID->"c3661df7-28f9-435c-bbf7-782b8dc5a39f"],
-Cell[212188, 5377, 175, 4, 77, "Print",ExpressionUUID->"56eb8f3b-e834-40f2-89fe-bebe451a9eaf"],
-Cell[212366, 5383, 174, 4, 77, "Print",ExpressionUUID->"81fbff44-36d6-41c3-8f01-4c007984dfc0"],
-Cell[212543, 5389, 174, 4, 77, "Print",ExpressionUUID->"be9d0845-859a-4fa0-b050-169ecddbe8f9"],
-Cell[212720, 5395, 175, 4, 77, "Print",ExpressionUUID->"4ac7fa36-f4ae-4957-94b2-a3904570dfae"],
-Cell[212898, 5401, 175, 4, 77, "Print",ExpressionUUID->"91bc5325-38d7-47e7-9acf-23d5a3510524"],
-Cell[213076, 5407, 175, 4, 77, "Print",ExpressionUUID->"dd9ae39b-0a87-458e-b5db-94edd1a33f62"],
-Cell[213254, 5413, 175, 4, 77, "Print",ExpressionUUID->"704d295f-c4f1-4d95-986b-d17f0c98a97b"],
-Cell[213432, 5419, 175, 4, 77, "Print",ExpressionUUID->"4949bf6e-6480-46c9-9b5d-5e2a63dc36b8"],
-Cell[213610, 5425, 175, 4, 77, "Print",ExpressionUUID->"b93da0ea-d2f0-4638-816f-b214b62923ac"],
-Cell[213788, 5431, 175, 4, 77, "Print",ExpressionUUID->"369d3273-4131-4c8c-8c98-f584a7e102bb"],
-Cell[213966, 5437, 175, 4, 77, "Print",ExpressionUUID->"ae3ca2a8-abbe-4435-939c-bc0aa4de6406"],
-Cell[214144, 5443, 177, 4, 77, "Print",ExpressionUUID->"48eaea15-73e4-491b-95df-9cabb2ddfcd4"],
-Cell[214324, 5449, 174, 4, 77, "Print",ExpressionUUID->"ab2fec67-fdcc-4fca-9f50-67634577071f"],
-Cell[214501, 5455, 175, 4, 77, "Print",ExpressionUUID->"a8fecff5-28bd-4ace-8a32-04094cb191c7"],
-Cell[214679, 5461, 175, 4, 77, "Print",ExpressionUUID->"b79d992d-f792-4c67-81f4-57f33654e77d"],
-Cell[214857, 5467, 177, 4, 77, "Print",ExpressionUUID->"ce1dd71c-bbed-458c-9e17-8f7357d28e28"],
-Cell[215037, 5473, 175, 4, 77, "Print",ExpressionUUID->"2709636c-f5a2-4c44-ae35-681925ac9b4f"],
-Cell[215215, 5479, 175, 4, 77, "Print",ExpressionUUID->"befa0176-8b68-420e-bd6b-556720ea3a3b"],
-Cell[215393, 5485, 174, 4, 77, "Print",ExpressionUUID->"64992c98-84b0-4c42-8514-e6d0a05c724e"],
-Cell[215570, 5491, 175, 4, 77, "Print",ExpressionUUID->"62a5c58a-813c-41c2-bbfb-00ed4eb9393f"],
-Cell[215748, 5497, 175, 4, 77, "Print",ExpressionUUID->"49734745-8278-408a-8332-ff2875b4a3f3"],
-Cell[215926, 5503, 175, 4, 77, "Print",ExpressionUUID->"8caa6573-9821-4d1e-90c2-255b5a73377a"],
-Cell[216104, 5509, 175, 4, 77, "Print",ExpressionUUID->"f435b1be-8ce8-49ea-b363-547dd7d47140"],
-Cell[216282, 5515, 175, 4, 77, "Print",ExpressionUUID->"0948d347-2a5d-4441-8893-d853c84d117a"],
-Cell[216460, 5521, 177, 4, 77, "Print",ExpressionUUID->"d8015628-228e-4f04-8025-08f7e5405e1c"],
-Cell[216640, 5527, 175, 4, 77, "Print",ExpressionUUID->"7fdbf41f-06ba-44eb-8afd-6fc726df7843"],
-Cell[216818, 5533, 175, 4, 77, "Print",ExpressionUUID->"fe2743e4-4500-43fd-9d31-928eb0ae38f7"],
-Cell[216996, 5539, 177, 4, 77, "Print",ExpressionUUID->"bbef09ac-5c54-450b-ac39-c3eff66dcc82"],
-Cell[217176, 5545, 175, 4, 77, "Print",ExpressionUUID->"5861a9c1-2c37-438a-bd68-626fd4eadf2a"],
-Cell[217354, 5551, 174, 4, 77, "Print",ExpressionUUID->"85c195a5-970b-4667-957a-c27d0707c000"],
-Cell[217531, 5557, 174, 4, 77, "Print",ExpressionUUID->"d468def5-38da-433e-b42c-39ab38d3b1ba"],
-Cell[217708, 5563, 173, 4, 77, "Print",ExpressionUUID->"4b978214-0bf5-4459-b4c2-2cf88209cf41"],
-Cell[217884, 5569, 176, 4, 77, "Print",ExpressionUUID->"31f562a7-61da-4f42-858b-2d8beb95fc17"],
-Cell[218063, 5575, 174, 4, 77, "Print",ExpressionUUID->"4ffab733-841c-4b9a-a62a-4acd0cf85842"],
-Cell[218240, 5581, 174, 4, 77, "Print",ExpressionUUID->"effbd569-d375-4094-9bc7-7a91016f814c"],
-Cell[218417, 5587, 174, 4, 77, "Print",ExpressionUUID->"268f59ad-b1d8-464a-ad03-0fb9937d14cc"],
-Cell[218594, 5593, 176, 4, 77, "Print",ExpressionUUID->"7df2767d-ff5d-40b6-9fc0-139202407890"],
-Cell[218773, 5599, 176, 4, 77, "Print",ExpressionUUID->"3e63b283-39da-4581-9de3-4fbbd243b423"],
-Cell[218952, 5605, 174, 4, 77, "Print",ExpressionUUID->"a10ef9b4-7759-40c5-a161-d432443d500d"],
-Cell[219129, 5611, 175, 4, 77, "Print",ExpressionUUID->"9e824373-4a70-44a0-9067-b18fd53de9ff"],
-Cell[219307, 5617, 175, 4, 77, "Print",ExpressionUUID->"c87c2c5e-35ae-4434-90af-6492a960a2d6"],
-Cell[219485, 5623, 177, 4, 77, "Print",ExpressionUUID->"06759cb9-f34e-45a3-b4d2-8b67916b2101"],
-Cell[219665, 5629, 177, 4, 77, "Print",ExpressionUUID->"6e909466-4933-4603-a780-35cf4f83b730"],
-Cell[219845, 5635, 177, 4, 77, "Print",ExpressionUUID->"f0439553-6b51-468f-ba4d-ceb4eece05a6"],
-Cell[220025, 5641, 174, 4, 77, "Print",ExpressionUUID->"94c6c9c5-c5b6-47f8-a2e5-c848a2f3527a"],
-Cell[220202, 5647, 177, 4, 77, "Print",ExpressionUUID->"b21666c0-c33e-43a1-8a46-eaad739b937e"],
-Cell[220382, 5653, 177, 4, 77, "Print",ExpressionUUID->"2c1a3de6-2c68-40fd-b715-c8a00f4c3600"],
-Cell[220562, 5659, 177, 4, 77, "Print",ExpressionUUID->"2f43e7aa-c80a-4ddf-9cf5-dabe7406b9e5"],
-Cell[220742, 5665, 175, 4, 77, "Print",ExpressionUUID->"e2517276-bcea-418e-a80a-d5779b905a11"],
-Cell[220920, 5671, 175, 4, 77, "Print",ExpressionUUID->"1412e7a8-bbe7-4a8c-b6a2-1d1f3962d3a3"],
-Cell[221098, 5677, 177, 4, 77, "Print",ExpressionUUID->"d99fb0f8-51e3-493e-b5ad-e03067b964cd"],
-Cell[221278, 5683, 175, 4, 77, "Print",ExpressionUUID->"c4beeaab-5add-46a7-92f7-9a47de950beb"],
-Cell[221456, 5689, 175, 4, 77, "Print",ExpressionUUID->"dff04fde-1385-44e8-8b06-508dff6c8e0d"],
-Cell[221634, 5695, 175, 4, 77, "Print",ExpressionUUID->"dfb8516e-aac1-4ec0-9ffd-7b176b18ef10"],
-Cell[221812, 5701, 175, 4, 77, "Print",ExpressionUUID->"a59dd75f-c567-42ff-8c8b-2a0e44ba002f"],
-Cell[221990, 5707, 177, 4, 77, "Print",ExpressionUUID->"8490c947-7cab-453b-9f97-491752d1a9d4"],
-Cell[222170, 5713, 175, 4, 77, "Print",ExpressionUUID->"982230fe-52cb-433e-9be6-bffcdb93e4bb"],
-Cell[222348, 5719, 177, 4, 77, "Print",ExpressionUUID->"a899d8b8-fe54-4b69-bbf2-6e0788a7140b"],
-Cell[222528, 5725, 175, 4, 77, "Print",ExpressionUUID->"4131cf67-014d-4cb1-8921-c1749c83e7c9"],
-Cell[222706, 5731, 175, 4, 77, "Print",ExpressionUUID->"8329b28d-be8f-42ef-b2f6-1ae682d8adf5"],
-Cell[222884, 5737, 175, 4, 77, "Print",ExpressionUUID->"5dc2eb17-7f5d-4b3d-9cae-e2f8f57ca030"],
-Cell[223062, 5743, 175, 4, 77, "Print",ExpressionUUID->"96fa7f65-5f4a-4b78-9c64-210e496a332d"],
-Cell[223240, 5749, 175, 4, 77, "Print",ExpressionUUID->"a516ae94-4554-419a-87b5-8494f5377084"],
-Cell[223418, 5755, 175, 4, 77, "Print",ExpressionUUID->"8b906f2b-1338-43c3-8f66-338c6725ca08"],
-Cell[223596, 5761, 175, 4, 77, "Print",ExpressionUUID->"9af700f5-034d-461a-b950-0698f3b395c2"],
-Cell[223774, 5767, 175, 4, 77, "Print",ExpressionUUID->"3f941b4e-65ae-4079-a857-e8eedfbf5f8e"],
-Cell[223952, 5773, 175, 4, 77, "Print",ExpressionUUID->"035fa53c-bf70-4544-a2c6-3be1356b7be5"],
-Cell[224130, 5779, 175, 4, 77, "Print",ExpressionUUID->"8b945cf2-85f9-42b5-b654-6c5e5f3afd30"],
-Cell[224308, 5785, 175, 4, 77, "Print",ExpressionUUID->"71304bc5-273a-41c6-921f-e5c928045495"],
-Cell[224486, 5791, 175, 4, 77, "Print",ExpressionUUID->"f21411da-507e-42a6-a03c-aed879ed385e"],
-Cell[224664, 5797, 174, 4, 77, "Print",ExpressionUUID->"024e5652-b3e6-493b-beb8-43b72645fcfb"],
-Cell[224841, 5803, 175, 4, 77, "Print",ExpressionUUID->"fded1e38-fb1f-46d8-aa49-9da4268dcd93"],
-Cell[225019, 5809, 177, 4, 77, "Print",ExpressionUUID->"11ea31af-510b-4388-82c7-a7a896ff2cd2"],
-Cell[225199, 5815, 175, 4, 77, "Print",ExpressionUUID->"da6d175b-970a-4c35-bb97-54df93aa6431"],
-Cell[225377, 5821, 175, 4, 77, "Print",ExpressionUUID->"7938ed33-5c29-477e-82ec-1154c1e2972b"],
-Cell[225555, 5827, 175, 4, 77, "Print",ExpressionUUID->"00bef6cf-f05b-456b-8e11-fc143453ed37"],
-Cell[225733, 5833, 177, 4, 77, "Print",ExpressionUUID->"6941759e-f71c-4ffc-aebd-52d55cdddebd"],
-Cell[225913, 5839, 174, 4, 77, "Print",ExpressionUUID->"073cc1a0-6b48-49e0-b132-cbeba4bba686"],
-Cell[226090, 5845, 173, 4, 77, "Print",ExpressionUUID->"e4ab7395-67eb-47e9-b089-28e010d32b7c"],
-Cell[226266, 5851, 174, 4, 77, "Print",ExpressionUUID->"3db1d58b-72b5-4d3a-a4a5-8a2b639ac828"],
-Cell[226443, 5857, 173, 4, 77, "Print",ExpressionUUID->"cc3984c2-5ac0-4e09-8642-673069327a4d"],
-Cell[226619, 5863, 176, 4, 77, "Print",ExpressionUUID->"7117a7ae-ed26-4fdc-a3aa-01ea342fb685"],
-Cell[226798, 5869, 174, 4, 77, "Print",ExpressionUUID->"796cad32-4430-4c7e-97f7-6caccd358760"],
-Cell[226975, 5875, 174, 4, 77, "Print",ExpressionUUID->"bb6be225-44ec-4ca0-bd31-c9f48c995d05"],
-Cell[227152, 5881, 174, 4, 77, "Print",ExpressionUUID->"1ec02e45-c7b2-4e01-bf56-7008fc85b8c1"],
-Cell[227329, 5887, 177, 4, 77, "Print",ExpressionUUID->"4e1c11f2-58fb-40bc-b74e-6af1aa5c9867"],
-Cell[227509, 5893, 175, 4, 77, "Print",ExpressionUUID->"1dede9f2-4076-4c81-835a-683b96c711fc"],
-Cell[227687, 5899, 175, 4, 77, "Print",ExpressionUUID->"36d04295-f94f-47f4-a455-9f0228243000"],
-Cell[227865, 5905, 175, 4, 77, "Print",ExpressionUUID->"c58b532b-7824-4df8-abc6-5fdaf1413ad9"],
-Cell[228043, 5911, 175, 4, 77, "Print",ExpressionUUID->"a87657d3-9295-416d-bd1b-c70d2ea77f34"],
-Cell[228221, 5917, 175, 4, 77, "Print",ExpressionUUID->"11c10423-c2c2-4dc7-9238-3dd6cee4876b"],
-Cell[228399, 5923, 174, 4, 77, "Print",ExpressionUUID->"388e95e2-c913-417b-b10e-a7d9623b618e"],
-Cell[228576, 5929, 175, 4, 77, "Print",ExpressionUUID->"0871ac75-2d0b-441d-bcb5-f99eb17a9f47"],
-Cell[228754, 5935, 175, 4, 77, "Print",ExpressionUUID->"21fa71a2-5f9b-44ff-987b-6abc92868cc8"],
-Cell[228932, 5941, 177, 4, 77, "Print",ExpressionUUID->"ef142a15-3ee9-4d3e-b702-a531230dd5b2"],
-Cell[229112, 5947, 174, 4, 77, "Print",ExpressionUUID->"2c7dd2d5-b467-49cf-b7d6-f9a838037421"],
-Cell[229289, 5953, 175, 4, 77, "Print",ExpressionUUID->"eb9d12ee-6049-460d-9758-6b4981ba062a"],
-Cell[229467, 5959, 175, 4, 77, "Print",ExpressionUUID->"f264bd3a-ea12-45fb-9db8-64effbee4af4"],
-Cell[229645, 5965, 175, 4, 77, "Print",ExpressionUUID->"23c4b0bc-e7e3-4e23-b205-ebe4326bd649"],
-Cell[229823, 5971, 177, 4, 77, "Print",ExpressionUUID->"82e98d1e-618f-4588-9e1f-859bce11c289"],
-Cell[230003, 5977, 175, 4, 77, "Print",ExpressionUUID->"e3d9e881-221c-47e1-9616-c998714cd449"],
-Cell[230181, 5983, 175, 4, 77, "Print",ExpressionUUID->"466112a2-c4d4-4ad7-95fa-dd3518f8be65"],
-Cell[230359, 5989, 177, 4, 77, "Print",ExpressionUUID->"5c2d7071-c0b2-4e38-b86e-639b521d2cba"],
-Cell[230539, 5995, 177, 4, 77, "Print",ExpressionUUID->"7b34f67f-8fba-48af-b0ed-15451510fb4d"],
-Cell[230719, 6001, 177, 4, 77, "Print",ExpressionUUID->"623b4ce0-9f63-42a3-8876-d6b85ec72c96"],
-Cell[230899, 6007, 175, 4, 77, "Print",ExpressionUUID->"cb3d7a50-1858-48a8-87fe-3688d64f6d13"],
-Cell[231077, 6013, 175, 4, 77, "Print",ExpressionUUID->"7ae44efa-2f18-4931-8be8-6fdc197f682d"],
-Cell[231255, 6019, 175, 4, 77, "Print",ExpressionUUID->"d5254600-0275-4b7f-b5cd-5c6e827a07ff"],
-Cell[231433, 6025, 177, 4, 77, "Print",ExpressionUUID->"485a1a92-0478-4c57-849e-811f426d41bd"],
-Cell[231613, 6031, 175, 4, 77, "Print",ExpressionUUID->"df1ff040-35ab-44d1-9c3a-4a5a3772590d"],
-Cell[231791, 6037, 175, 4, 77, "Print",ExpressionUUID->"fce9d9aa-f1a0-4985-bd1b-2b882e14335f"],
-Cell[231969, 6043, 175, 4, 77, "Print",ExpressionUUID->"06f30b07-7add-49c4-8463-b755584eb43b"],
-Cell[232147, 6049, 174, 4, 77, "Print",ExpressionUUID->"93c22934-1939-4865-9f9d-4e11565eee9d"],
-Cell[232324, 6055, 177, 4, 77, "Print",ExpressionUUID->"003e7603-d839-4c4f-9b4e-ab7dabc24820"],
-Cell[232504, 6061, 175, 4, 77, "Print",ExpressionUUID->"43504828-066f-444b-a2f0-565038113fcf"],
-Cell[232682, 6067, 177, 4, 77, "Print",ExpressionUUID->"e48b0879-c226-4a6c-a6d3-3c616134e073"],
-Cell[232862, 6073, 177, 4, 77, "Print",ExpressionUUID->"3efbc823-c03f-4fd6-8e13-c8c4531e99ed"],
-Cell[233042, 6079, 175, 4, 77, "Print",ExpressionUUID->"a1a87166-0177-42c5-a6ba-56298cc8a77a"],
-Cell[233220, 6085, 174, 4, 77, "Print",ExpressionUUID->"15f9bc51-203e-4507-98e7-476691ca1f7a"],
-Cell[233397, 6091, 177, 4, 77, "Print",ExpressionUUID->"321cc4bf-c073-46bb-b2f5-cf84a42f1933"],
-Cell[233577, 6097, 175, 4, 77, "Print",ExpressionUUID->"e78112c1-64a4-46f2-ad85-f1a9dde2f13e"],
-Cell[233755, 6103, 177, 4, 77, "Print",ExpressionUUID->"5e60ba3d-4cd5-4a7c-af74-fcc16ef8d7d0"],
-Cell[233935, 6109, 175, 4, 77, "Print",ExpressionUUID->"5d6144fe-7510-4411-a26a-fdda8dca9da9"],
-Cell[234113, 6115, 177, 4, 77, "Print",ExpressionUUID->"eafa4e99-b51d-4e83-a60a-0fa4ccb2a2be"]
+Cell[191192, 4709, 198, 4, 25, "Print",ExpressionUUID->"c5b5dc1e-7a49-4adb-9c36-9eeebd73773a"],
+Cell[191393, 4715, 200, 4, 25, "Print",ExpressionUUID->"060fed66-0143-4c9f-bdb4-0bfe97a2da78"],
+Cell[191596, 4721, 198, 4, 25, "Print",ExpressionUUID->"07abd5cc-939e-4e0b-b88f-4721b55999f1"],
+Cell[191797, 4727, 198, 4, 25, "Print",ExpressionUUID->"153fe3e6-8ac9-4895-b819-442ad1499b9b"],
+Cell[191998, 4733, 198, 4, 25, "Print",ExpressionUUID->"1c694cb2-1edc-4da3-b6bf-f1cc3d79d159"],
+Cell[192199, 4739, 198, 4, 25, "Print",ExpressionUUID->"8c47e9cb-e216-42d9-b591-f179d4242056"],
+Cell[192400, 4745, 200, 4, 25, "Print",ExpressionUUID->"88fcfc98-ea19-42c4-bd9d-0a5c196dc2b2"],
+Cell[192603, 4751, 198, 4, 25, "Print",ExpressionUUID->"45ca3fa1-bb31-4784-b532-cfda5865c49d"],
+Cell[192804, 4757, 199, 4, 25, "Print",ExpressionUUID->"88c7d300-26e1-4374-9195-ab8e41402fe5"],
+Cell[193006, 4763, 199, 4, 25, "Print",ExpressionUUID->"adc02e62-6f94-4ed6-812b-49ed3fe3ef34"],
+Cell[193208, 4769, 199, 4, 25, "Print",ExpressionUUID->"449d4b9f-a2ae-458b-b82f-c98eb71d4128"],
+Cell[193410, 4775, 199, 4, 25, "Print",ExpressionUUID->"1109e18f-e0b7-4bec-983b-f1988b9f4e9e"],
+Cell[193612, 4781, 199, 4, 25, "Print",ExpressionUUID->"c6f8f3b1-9489-4592-8199-89b939468b21"],
+Cell[193814, 4787, 199, 4, 25, "Print",ExpressionUUID->"eccae9b8-fb42-4b35-998c-ac0f6975e07c"],
+Cell[194016, 4793, 199, 4, 25, "Print",ExpressionUUID->"b1b9d7c4-b209-4c08-b3e5-1bc64b0bdd6a"],
+Cell[194218, 4799, 199, 4, 25, "Print",ExpressionUUID->"dfa87c64-90a1-4e3e-b220-8826f05bb855"],
+Cell[194420, 4805, 201, 4, 25, "Print",ExpressionUUID->"ff1c30b6-fdcf-420d-80ba-781c6865e260"],
+Cell[194624, 4811, 199, 4, 25, "Print",ExpressionUUID->"27eae6cc-581d-4858-9570-06c969011b13"],
+Cell[194826, 4817, 201, 4, 25, "Print",ExpressionUUID->"79fab8cc-19ab-47dd-b4a0-66bf71854016"],
+Cell[195030, 4823, 199, 4, 25, "Print",ExpressionUUID->"3ae68728-c0de-4cc9-99d8-e6eccdd5d717"],
+Cell[195232, 4829, 201, 4, 25, "Print",ExpressionUUID->"b8cdb15d-bd62-42b7-8ab8-0ed37c0c8763"],
+Cell[195436, 4835, 199, 4, 25, "Print",ExpressionUUID->"e90eeeb1-92f0-4c35-aff3-b4a9c87da6ce"],
+Cell[195638, 4841, 199, 4, 25, "Print",ExpressionUUID->"cdbf3cc9-e084-49ef-a718-03e6b6b64658"],
+Cell[195840, 4847, 199, 4, 25, "Print",ExpressionUUID->"9a543198-c3d2-4809-9e96-30a0c652ee2c"],
+Cell[196042, 4853, 201, 4, 25, "Print",ExpressionUUID->"2d6c405c-34be-487c-a732-cbcdb2e88938"],
+Cell[196246, 4859, 201, 4, 25, "Print",ExpressionUUID->"bf4493f2-aa67-4921-bbd4-95d5d41d6899"],
+Cell[196450, 4865, 199, 4, 25, "Print",ExpressionUUID->"054ae59f-56c9-4b83-a827-9fbd347896ed"],
+Cell[196652, 4871, 199, 4, 25, "Print",ExpressionUUID->"41657ef1-ab20-4839-a89b-8b62c2bd57ac"],
+Cell[196854, 4877, 199, 4, 25, "Print",ExpressionUUID->"121e65c2-5d87-47ef-b9b2-242a9dd1e8c9"],
+Cell[197056, 4883, 199, 4, 25, "Print",ExpressionUUID->"22188474-f152-453a-855f-ba1ca6c3ad3e"],
+Cell[197258, 4889, 201, 4, 25, "Print",ExpressionUUID->"9f1f505d-ca0c-4dd6-8347-dadaf6c8d04f"],
+Cell[197462, 4895, 201, 4, 25, "Print",ExpressionUUID->"3b35a460-4325-4918-883e-4fc0a4d52129"],
+Cell[197666, 4901, 199, 4, 25, "Print",ExpressionUUID->"43dd121d-ff45-422a-b6c8-9affd72a2fef"],
+Cell[197868, 4907, 201, 4, 25, "Print",ExpressionUUID->"f72534f2-9a10-4ace-ac3d-401c8fb5c37b"],
+Cell[198072, 4913, 201, 4, 25, "Print",ExpressionUUID->"f2fcc307-53b1-4479-808d-529e282765aa"],
+Cell[198276, 4919, 201, 4, 25, "Print",ExpressionUUID->"9e098dad-7892-436f-aa78-c56dc07ede97"],
+Cell[198480, 4925, 201, 4, 25, "Print",ExpressionUUID->"07455b67-3d6a-4bd1-92a9-c73215ca505a"],
+Cell[198684, 4931, 199, 4, 25, "Print",ExpressionUUID->"0ffcc929-dc2a-4bd1-9a37-e28663b3ab4b"],
+Cell[198886, 4937, 199, 4, 25, "Print",ExpressionUUID->"b544bda8-153d-4c29-9e96-100bac875f1e"],
+Cell[199088, 4943, 201, 4, 25, "Print",ExpressionUUID->"f1d35551-dddf-42dc-baaa-c15108f8a255"],
+Cell[199292, 4949, 198, 4, 25, "Print",ExpressionUUID->"40b508b0-eaff-4945-acd9-7ac57b551b9f"],
+Cell[199493, 4955, 199, 4, 25, "Print",ExpressionUUID->"0545a95e-674a-4aeb-9e3b-7224394a1081"],
+Cell[199695, 4961, 201, 4, 25, "Print",ExpressionUUID->"b6de5818-dce8-445a-82c5-aa7bc0f79dff"],
+Cell[199899, 4967, 198, 4, 25, "Print",ExpressionUUID->"6221c72a-071e-46bd-b8d2-c30607c8b4d2"],
+Cell[200100, 4973, 198, 4, 25, "Print",ExpressionUUID->"66155384-14ea-4737-8e00-676991c6b754"],
+Cell[200301, 4979, 199, 4, 25, "Print",ExpressionUUID->"2252c55f-9572-4d83-9c12-7af99ad46644"],
+Cell[200503, 4985, 199, 4, 25, "Print",ExpressionUUID->"438b69cc-1a39-4c1a-9633-edf63b87edb4"],
+Cell[200705, 4991, 174, 4, 77, "Print",ExpressionUUID->"f5e7e907-17a6-434b-97b4-449792f39e92"],
+Cell[200882, 4997, 176, 4, 77, "Print",ExpressionUUID->"c02f216e-79a8-4b53-becd-0c00ec4b8c41"],
+Cell[201061, 5003, 174, 4, 77, "Print",ExpressionUUID->"3b46a7bc-24e0-47f9-9295-c39b079a2529"],
+Cell[201238, 5009, 176, 4, 77, "Print",ExpressionUUID->"60b8ac53-237f-4eae-90f2-18e8bbbc7b79"],
+Cell[201417, 5015, 174, 4, 77, "Print",ExpressionUUID->"6a0e4594-6d40-4ca3-bcb3-8a780fee3445"],
+Cell[201594, 5021, 174, 4, 77, "Print",ExpressionUUID->"847855c6-157a-4944-9381-1609ecb3010d"],
+Cell[201771, 5027, 174, 4, 77, "Print",ExpressionUUID->"5b8d8877-68e0-4c1f-b432-869a6ba630a0"],
+Cell[201948, 5033, 174, 4, 77, "Print",ExpressionUUID->"466c8858-a401-4888-b107-ce4d35ee85a6"],
+Cell[202125, 5039, 175, 4, 77, "Print",ExpressionUUID->"68416fc0-e13b-4e2d-b9c4-34bfa8ccdd7a"],
+Cell[202303, 5045, 177, 4, 77, "Print",ExpressionUUID->"e8c24090-3901-4e66-95b8-d04366254b4e"],
+Cell[202483, 5051, 177, 4, 77, "Print",ExpressionUUID->"d333cc16-c0b3-4d52-a035-f11b0f83cf32"],
+Cell[202663, 5057, 175, 4, 77, "Print",ExpressionUUID->"379c8ddd-841d-46c0-b719-9d33f1957bd1"],
+Cell[202841, 5063, 174, 4, 77, "Print",ExpressionUUID->"a1b5491a-ae07-4b61-9719-49b73db33192"],
+Cell[203018, 5069, 175, 4, 77, "Print",ExpressionUUID->"8723c5cf-9175-4dbf-a09e-42cbd5067df9"],
+Cell[203196, 5075, 175, 4, 77, "Print",ExpressionUUID->"7a119cb1-a9c8-4bf3-983c-60bb5d882c7c"],
+Cell[203374, 5081, 174, 4, 77, "Print",ExpressionUUID->"0438a27e-b3af-41e3-a378-b9115071d6db"],
+Cell[203551, 5087, 177, 4, 77, "Print",ExpressionUUID->"a3b5652d-b12b-4b22-8bda-4ecd87807880"],
+Cell[203731, 5093, 174, 4, 77, "Print",ExpressionUUID->"4387bbbf-4b92-43c1-a54a-bb5ecff983b5"],
+Cell[203908, 5099, 175, 4, 77, "Print",ExpressionUUID->"424881d8-a5ae-41fb-9cbe-730e3c0a2bb0"],
+Cell[204086, 5105, 175, 4, 77, "Print",ExpressionUUID->"d8b112d2-277f-45cb-acae-bfcd9d460ecf"],
+Cell[204264, 5111, 175, 4, 77, "Print",ExpressionUUID->"46d82a89-a0f1-4a6e-84ee-ef5628194ada"],
+Cell[204442, 5117, 175, 4, 77, "Print",ExpressionUUID->"8935cb61-62f4-4825-9de0-1ee34b19725e"],
+Cell[204620, 5123, 175, 4, 77, "Print",ExpressionUUID->"176c9180-582a-475f-952d-4d043dc4693b"],
+Cell[204798, 5129, 175, 4, 77, "Print",ExpressionUUID->"ae2a17c4-3bb9-4cb3-901d-672400d279b0"],
+Cell[204976, 5135, 177, 4, 77, "Print",ExpressionUUID->"47c7ba5d-69d6-4459-bb63-7eeb84d0cc15"],
+Cell[205156, 5141, 173, 4, 77, "Print",ExpressionUUID->"17d7c441-bd99-4d55-86eb-4862a3aa8e84"],
+Cell[205332, 5147, 177, 4, 77, "Print",ExpressionUUID->"9343ac10-a007-4cdf-b232-e6813c80dfff"],
+Cell[205512, 5153, 175, 4, 77, "Print",ExpressionUUID->"3b72fe81-8347-48fc-a4df-9be0bb7457b3"],
+Cell[205690, 5159, 175, 4, 77, "Print",ExpressionUUID->"fec764f7-d5cb-4e41-ac37-877124dc01ed"],
+Cell[205868, 5165, 175, 4, 77, "Print",ExpressionUUID->"44341dbf-dfd8-4b26-92b0-e64a33c029cf"],
+Cell[206046, 5171, 175, 4, 77, "Print",ExpressionUUID->"8621872a-c0ce-402b-8b44-129d5571be77"],
+Cell[206224, 5177, 174, 4, 77, "Print",ExpressionUUID->"35bc48f8-26a6-43bf-a980-1cd915790d0e"],
+Cell[206401, 5183, 175, 4, 77, "Print",ExpressionUUID->"1afb2d14-8699-4b84-a0cc-67814f3b7f0d"],
+Cell[206579, 5189, 175, 4, 77, "Print",ExpressionUUID->"e518f44b-1671-4c5f-9b01-6ac5a8b02fa5"],
+Cell[206757, 5195, 174, 4, 77, "Print",ExpressionUUID->"3bd7dc34-3439-463a-aeca-b5826ab262d2"],
+Cell[206934, 5201, 175, 4, 77, "Print",ExpressionUUID->"6f0ce850-04be-43ac-a000-a8e2d99214ca"],
+Cell[207112, 5207, 175, 4, 77, "Print",ExpressionUUID->"c982f935-cf77-4eed-856a-095607853357"],
+Cell[207290, 5213, 175, 4, 77, "Print",ExpressionUUID->"69ee4881-5725-49cf-bee5-c9cb306a66b7"],
+Cell[207468, 5219, 177, 4, 77, "Print",ExpressionUUID->"6e84f5bc-6c6c-40f2-aae4-028bcce649dd"],
+Cell[207648, 5225, 175, 4, 77, "Print",ExpressionUUID->"68f4a1c9-d47e-4c02-931e-6b09eee55c72"],
+Cell[207826, 5231, 177, 4, 77, "Print",ExpressionUUID->"85f186c3-06b0-4034-90e8-a2a0ca9c9cd4"],
+Cell[208006, 5237, 177, 4, 77, "Print",ExpressionUUID->"d4ac599e-686d-491c-9c65-91f7ba8f4c5b"],
+Cell[208186, 5243, 175, 4, 77, "Print",ExpressionUUID->"2259e8a5-51da-4e16-8d66-6db6785d2f44"],
+Cell[208364, 5249, 175, 4, 77, "Print",ExpressionUUID->"6e6f7f03-be91-4bd4-ad8e-0efa6ed95fe5"],
+Cell[208542, 5255, 175, 4, 77, "Print",ExpressionUUID->"163e8b59-b650-4f06-8f69-31f95cf60883"],
+Cell[208720, 5261, 175, 4, 77, "Print",ExpressionUUID->"f91018f8-e572-4ad5-a49c-100139ffe9d4"],
+Cell[208898, 5267, 175, 4, 77, "Print",ExpressionUUID->"77a0ab60-b198-4afe-b0ff-2cde2b87db2c"],
+Cell[209076, 5273, 174, 4, 77, "Print",ExpressionUUID->"70df2d90-c3e8-4775-bd9c-28e8de94e374"],
+Cell[209253, 5279, 174, 4, 77, "Print",ExpressionUUID->"9d9e0200-c495-4719-9ea6-ba48eda4af7d"],
+Cell[209430, 5285, 174, 4, 77, "Print",ExpressionUUID->"4785ae0a-d8ae-492b-9bf9-cda425b0b011"],
+Cell[209607, 5291, 174, 4, 77, "Print",ExpressionUUID->"13108136-c303-4bf3-b8e8-511a67410fff"],
+Cell[209784, 5297, 174, 4, 77, "Print",ExpressionUUID->"38a852da-0a04-4621-93eb-df7315e30f1c"],
+Cell[209961, 5303, 174, 4, 77, "Print",ExpressionUUID->"ba5fe259-2013-4bbb-a9e8-8048848db0b5"],
+Cell[210138, 5309, 174, 4, 77, "Print",ExpressionUUID->"4f013174-e794-4719-adc5-160049763b7a"],
+Cell[210315, 5315, 174, 4, 77, "Print",ExpressionUUID->"d2ef1ba8-f373-4a11-acca-4d3a51e69084"],
+Cell[210492, 5321, 175, 4, 77, "Print",ExpressionUUID->"b198af96-c8df-46c8-88bd-cdf5285642cb"],
+Cell[210670, 5327, 175, 4, 77, "Print",ExpressionUUID->"fb0b58cb-0660-4827-b78e-7ca3110c14fa"],
+Cell[210848, 5333, 175, 4, 77, "Print",ExpressionUUID->"166ce08d-acea-415d-9a72-688b0af44a76"],
+Cell[211026, 5339, 174, 4, 77, "Print",ExpressionUUID->"59d9ae9d-e1be-4206-9240-370006ea4652"],
+Cell[211203, 5345, 175, 4, 77, "Print",ExpressionUUID->"d9879f24-84a2-43bc-8fe5-30fc78f50680"],
+Cell[211381, 5351, 175, 4, 77, "Print",ExpressionUUID->"a89b8736-50f7-4cd2-b621-90cc46b95261"],
+Cell[211559, 5357, 175, 4, 77, "Print",ExpressionUUID->"4704cb3b-ed0c-4bf2-9363-a467da372110"],
+Cell[211737, 5363, 177, 4, 77, "Print",ExpressionUUID->"e1b2bbcf-59cd-4856-90c5-6ed1e22dfe84"],
+Cell[211917, 5369, 177, 4, 77, "Print",ExpressionUUID->"c3661df7-28f9-435c-bbf7-782b8dc5a39f"],
+Cell[212097, 5375, 175, 4, 77, "Print",ExpressionUUID->"56eb8f3b-e834-40f2-89fe-bebe451a9eaf"],
+Cell[212275, 5381, 174, 4, 77, "Print",ExpressionUUID->"81fbff44-36d6-41c3-8f01-4c007984dfc0"],
+Cell[212452, 5387, 174, 4, 77, "Print",ExpressionUUID->"be9d0845-859a-4fa0-b050-169ecddbe8f9"],
+Cell[212629, 5393, 175, 4, 77, "Print",ExpressionUUID->"4ac7fa36-f4ae-4957-94b2-a3904570dfae"],
+Cell[212807, 5399, 175, 4, 77, "Print",ExpressionUUID->"91bc5325-38d7-47e7-9acf-23d5a3510524"],
+Cell[212985, 5405, 175, 4, 77, "Print",ExpressionUUID->"dd9ae39b-0a87-458e-b5db-94edd1a33f62"],
+Cell[213163, 5411, 175, 4, 77, "Print",ExpressionUUID->"704d295f-c4f1-4d95-986b-d17f0c98a97b"],
+Cell[213341, 5417, 175, 4, 77, "Print",ExpressionUUID->"4949bf6e-6480-46c9-9b5d-5e2a63dc36b8"],
+Cell[213519, 5423, 175, 4, 77, "Print",ExpressionUUID->"b93da0ea-d2f0-4638-816f-b214b62923ac"],
+Cell[213697, 5429, 175, 4, 77, "Print",ExpressionUUID->"369d3273-4131-4c8c-8c98-f584a7e102bb"],
+Cell[213875, 5435, 175, 4, 77, "Print",ExpressionUUID->"ae3ca2a8-abbe-4435-939c-bc0aa4de6406"],
+Cell[214053, 5441, 177, 4, 77, "Print",ExpressionUUID->"48eaea15-73e4-491b-95df-9cabb2ddfcd4"],
+Cell[214233, 5447, 174, 4, 77, "Print",ExpressionUUID->"ab2fec67-fdcc-4fca-9f50-67634577071f"],
+Cell[214410, 5453, 175, 4, 77, "Print",ExpressionUUID->"a8fecff5-28bd-4ace-8a32-04094cb191c7"],
+Cell[214588, 5459, 175, 4, 77, "Print",ExpressionUUID->"b79d992d-f792-4c67-81f4-57f33654e77d"],
+Cell[214766, 5465, 177, 4, 77, "Print",ExpressionUUID->"ce1dd71c-bbed-458c-9e17-8f7357d28e28"],
+Cell[214946, 5471, 175, 4, 77, "Print",ExpressionUUID->"2709636c-f5a2-4c44-ae35-681925ac9b4f"],
+Cell[215124, 5477, 175, 4, 77, "Print",ExpressionUUID->"befa0176-8b68-420e-bd6b-556720ea3a3b"],
+Cell[215302, 5483, 174, 4, 77, "Print",ExpressionUUID->"64992c98-84b0-4c42-8514-e6d0a05c724e"],
+Cell[215479, 5489, 175, 4, 77, "Print",ExpressionUUID->"62a5c58a-813c-41c2-bbfb-00ed4eb9393f"],
+Cell[215657, 5495, 175, 4, 77, "Print",ExpressionUUID->"49734745-8278-408a-8332-ff2875b4a3f3"],
+Cell[215835, 5501, 175, 4, 77, "Print",ExpressionUUID->"8caa6573-9821-4d1e-90c2-255b5a73377a"],
+Cell[216013, 5507, 175, 4, 77, "Print",ExpressionUUID->"f435b1be-8ce8-49ea-b363-547dd7d47140"],
+Cell[216191, 5513, 175, 4, 77, "Print",ExpressionUUID->"0948d347-2a5d-4441-8893-d853c84d117a"],
+Cell[216369, 5519, 177, 4, 77, "Print",ExpressionUUID->"d8015628-228e-4f04-8025-08f7e5405e1c"],
+Cell[216549, 5525, 175, 4, 77, "Print",ExpressionUUID->"7fdbf41f-06ba-44eb-8afd-6fc726df7843"],
+Cell[216727, 5531, 175, 4, 77, "Print",ExpressionUUID->"fe2743e4-4500-43fd-9d31-928eb0ae38f7"],
+Cell[216905, 5537, 177, 4, 77, "Print",ExpressionUUID->"bbef09ac-5c54-450b-ac39-c3eff66dcc82"],
+Cell[217085, 5543, 175, 4, 77, "Print",ExpressionUUID->"5861a9c1-2c37-438a-bd68-626fd4eadf2a"],
+Cell[217263, 5549, 174, 4, 77, "Print",ExpressionUUID->"85c195a5-970b-4667-957a-c27d0707c000"],
+Cell[217440, 5555, 174, 4, 77, "Print",ExpressionUUID->"d468def5-38da-433e-b42c-39ab38d3b1ba"],
+Cell[217617, 5561, 173, 4, 77, "Print",ExpressionUUID->"4b978214-0bf5-4459-b4c2-2cf88209cf41"],
+Cell[217793, 5567, 176, 4, 77, "Print",ExpressionUUID->"31f562a7-61da-4f42-858b-2d8beb95fc17"],
+Cell[217972, 5573, 174, 4, 77, "Print",ExpressionUUID->"4ffab733-841c-4b9a-a62a-4acd0cf85842"],
+Cell[218149, 5579, 174, 4, 77, "Print",ExpressionUUID->"effbd569-d375-4094-9bc7-7a91016f814c"],
+Cell[218326, 5585, 174, 4, 77, "Print",ExpressionUUID->"268f59ad-b1d8-464a-ad03-0fb9937d14cc"],
+Cell[218503, 5591, 176, 4, 77, "Print",ExpressionUUID->"7df2767d-ff5d-40b6-9fc0-139202407890"],
+Cell[218682, 5597, 176, 4, 77, "Print",ExpressionUUID->"3e63b283-39da-4581-9de3-4fbbd243b423"],
+Cell[218861, 5603, 174, 4, 77, "Print",ExpressionUUID->"a10ef9b4-7759-40c5-a161-d432443d500d"],
+Cell[219038, 5609, 175, 4, 77, "Print",ExpressionUUID->"9e824373-4a70-44a0-9067-b18fd53de9ff"],
+Cell[219216, 5615, 175, 4, 77, "Print",ExpressionUUID->"c87c2c5e-35ae-4434-90af-6492a960a2d6"],
+Cell[219394, 5621, 177, 4, 77, "Print",ExpressionUUID->"06759cb9-f34e-45a3-b4d2-8b67916b2101"],
+Cell[219574, 5627, 177, 4, 77, "Print",ExpressionUUID->"6e909466-4933-4603-a780-35cf4f83b730"],
+Cell[219754, 5633, 177, 4, 77, "Print",ExpressionUUID->"f0439553-6b51-468f-ba4d-ceb4eece05a6"],
+Cell[219934, 5639, 174, 4, 77, "Print",ExpressionUUID->"94c6c9c5-c5b6-47f8-a2e5-c848a2f3527a"],
+Cell[220111, 5645, 177, 4, 77, "Print",ExpressionUUID->"b21666c0-c33e-43a1-8a46-eaad739b937e"],
+Cell[220291, 5651, 177, 4, 77, "Print",ExpressionUUID->"2c1a3de6-2c68-40fd-b715-c8a00f4c3600"],
+Cell[220471, 5657, 177, 4, 77, "Print",ExpressionUUID->"2f43e7aa-c80a-4ddf-9cf5-dabe7406b9e5"],
+Cell[220651, 5663, 175, 4, 77, "Print",ExpressionUUID->"e2517276-bcea-418e-a80a-d5779b905a11"],
+Cell[220829, 5669, 175, 4, 77, "Print",ExpressionUUID->"1412e7a8-bbe7-4a8c-b6a2-1d1f3962d3a3"],
+Cell[221007, 5675, 177, 4, 77, "Print",ExpressionUUID->"d99fb0f8-51e3-493e-b5ad-e03067b964cd"],
+Cell[221187, 5681, 175, 4, 77, "Print",ExpressionUUID->"c4beeaab-5add-46a7-92f7-9a47de950beb"],
+Cell[221365, 5687, 175, 4, 77, "Print",ExpressionUUID->"dff04fde-1385-44e8-8b06-508dff6c8e0d"],
+Cell[221543, 5693, 175, 4, 77, "Print",ExpressionUUID->"dfb8516e-aac1-4ec0-9ffd-7b176b18ef10"],
+Cell[221721, 5699, 175, 4, 77, "Print",ExpressionUUID->"a59dd75f-c567-42ff-8c8b-2a0e44ba002f"],
+Cell[221899, 5705, 177, 4, 77, "Print",ExpressionUUID->"8490c947-7cab-453b-9f97-491752d1a9d4"],
+Cell[222079, 5711, 175, 4, 77, "Print",ExpressionUUID->"982230fe-52cb-433e-9be6-bffcdb93e4bb"],
+Cell[222257, 5717, 177, 4, 77, "Print",ExpressionUUID->"a899d8b8-fe54-4b69-bbf2-6e0788a7140b"],
+Cell[222437, 5723, 175, 4, 77, "Print",ExpressionUUID->"4131cf67-014d-4cb1-8921-c1749c83e7c9"],
+Cell[222615, 5729, 175, 4, 77, "Print",ExpressionUUID->"8329b28d-be8f-42ef-b2f6-1ae682d8adf5"],
+Cell[222793, 5735, 175, 4, 77, "Print",ExpressionUUID->"5dc2eb17-7f5d-4b3d-9cae-e2f8f57ca030"],
+Cell[222971, 5741, 175, 4, 77, "Print",ExpressionUUID->"96fa7f65-5f4a-4b78-9c64-210e496a332d"],
+Cell[223149, 5747, 175, 4, 77, "Print",ExpressionUUID->"a516ae94-4554-419a-87b5-8494f5377084"],
+Cell[223327, 5753, 175, 4, 77, "Print",ExpressionUUID->"8b906f2b-1338-43c3-8f66-338c6725ca08"],
+Cell[223505, 5759, 175, 4, 77, "Print",ExpressionUUID->"9af700f5-034d-461a-b950-0698f3b395c2"],
+Cell[223683, 5765, 175, 4, 77, "Print",ExpressionUUID->"3f941b4e-65ae-4079-a857-e8eedfbf5f8e"],
+Cell[223861, 5771, 175, 4, 77, "Print",ExpressionUUID->"035fa53c-bf70-4544-a2c6-3be1356b7be5"],
+Cell[224039, 5777, 175, 4, 77, "Print",ExpressionUUID->"8b945cf2-85f9-42b5-b654-6c5e5f3afd30"],
+Cell[224217, 5783, 175, 4, 77, "Print",ExpressionUUID->"71304bc5-273a-41c6-921f-e5c928045495"],
+Cell[224395, 5789, 175, 4, 77, "Print",ExpressionUUID->"f21411da-507e-42a6-a03c-aed879ed385e"],
+Cell[224573, 5795, 174, 4, 77, "Print",ExpressionUUID->"024e5652-b3e6-493b-beb8-43b72645fcfb"],
+Cell[224750, 5801, 175, 4, 77, "Print",ExpressionUUID->"fded1e38-fb1f-46d8-aa49-9da4268dcd93"],
+Cell[224928, 5807, 177, 4, 77, "Print",ExpressionUUID->"11ea31af-510b-4388-82c7-a7a896ff2cd2"],
+Cell[225108, 5813, 175, 4, 77, "Print",ExpressionUUID->"da6d175b-970a-4c35-bb97-54df93aa6431"],
+Cell[225286, 5819, 175, 4, 77, "Print",ExpressionUUID->"7938ed33-5c29-477e-82ec-1154c1e2972b"],
+Cell[225464, 5825, 175, 4, 77, "Print",ExpressionUUID->"00bef6cf-f05b-456b-8e11-fc143453ed37"],
+Cell[225642, 5831, 177, 4, 77, "Print",ExpressionUUID->"6941759e-f71c-4ffc-aebd-52d55cdddebd"],
+Cell[225822, 5837, 174, 4, 77, "Print",ExpressionUUID->"073cc1a0-6b48-49e0-b132-cbeba4bba686"],
+Cell[225999, 5843, 173, 4, 77, "Print",ExpressionUUID->"e4ab7395-67eb-47e9-b089-28e010d32b7c"],
+Cell[226175, 5849, 174, 4, 77, "Print",ExpressionUUID->"3db1d58b-72b5-4d3a-a4a5-8a2b639ac828"],
+Cell[226352, 5855, 173, 4, 77, "Print",ExpressionUUID->"cc3984c2-5ac0-4e09-8642-673069327a4d"],
+Cell[226528, 5861, 176, 4, 77, "Print",ExpressionUUID->"7117a7ae-ed26-4fdc-a3aa-01ea342fb685"],
+Cell[226707, 5867, 174, 4, 77, "Print",ExpressionUUID->"796cad32-4430-4c7e-97f7-6caccd358760"],
+Cell[226884, 5873, 174, 4, 77, "Print",ExpressionUUID->"bb6be225-44ec-4ca0-bd31-c9f48c995d05"],
+Cell[227061, 5879, 174, 4, 77, "Print",ExpressionUUID->"1ec02e45-c7b2-4e01-bf56-7008fc85b8c1"],
+Cell[227238, 5885, 177, 4, 77, "Print",ExpressionUUID->"4e1c11f2-58fb-40bc-b74e-6af1aa5c9867"],
+Cell[227418, 5891, 175, 4, 77, "Print",ExpressionUUID->"1dede9f2-4076-4c81-835a-683b96c711fc"],
+Cell[227596, 5897, 175, 4, 77, "Print",ExpressionUUID->"36d04295-f94f-47f4-a455-9f0228243000"],
+Cell[227774, 5903, 175, 4, 77, "Print",ExpressionUUID->"c58b532b-7824-4df8-abc6-5fdaf1413ad9"],
+Cell[227952, 5909, 175, 4, 77, "Print",ExpressionUUID->"a87657d3-9295-416d-bd1b-c70d2ea77f34"],
+Cell[228130, 5915, 175, 4, 77, "Print",ExpressionUUID->"11c10423-c2c2-4dc7-9238-3dd6cee4876b"],
+Cell[228308, 5921, 174, 4, 77, "Print",ExpressionUUID->"388e95e2-c913-417b-b10e-a7d9623b618e"],
+Cell[228485, 5927, 175, 4, 77, "Print",ExpressionUUID->"0871ac75-2d0b-441d-bcb5-f99eb17a9f47"],
+Cell[228663, 5933, 175, 4, 77, "Print",ExpressionUUID->"21fa71a2-5f9b-44ff-987b-6abc92868cc8"],
+Cell[228841, 5939, 177, 4, 77, "Print",ExpressionUUID->"ef142a15-3ee9-4d3e-b702-a531230dd5b2"],
+Cell[229021, 5945, 174, 4, 77, "Print",ExpressionUUID->"2c7dd2d5-b467-49cf-b7d6-f9a838037421"],
+Cell[229198, 5951, 175, 4, 77, "Print",ExpressionUUID->"eb9d12ee-6049-460d-9758-6b4981ba062a"],
+Cell[229376, 5957, 175, 4, 77, "Print",ExpressionUUID->"f264bd3a-ea12-45fb-9db8-64effbee4af4"],
+Cell[229554, 5963, 175, 4, 77, "Print",ExpressionUUID->"23c4b0bc-e7e3-4e23-b205-ebe4326bd649"],
+Cell[229732, 5969, 177, 4, 77, "Print",ExpressionUUID->"82e98d1e-618f-4588-9e1f-859bce11c289"],
+Cell[229912, 5975, 175, 4, 77, "Print",ExpressionUUID->"e3d9e881-221c-47e1-9616-c998714cd449"],
+Cell[230090, 5981, 175, 4, 77, "Print",ExpressionUUID->"466112a2-c4d4-4ad7-95fa-dd3518f8be65"],
+Cell[230268, 5987, 177, 4, 77, "Print",ExpressionUUID->"5c2d7071-c0b2-4e38-b86e-639b521d2cba"],
+Cell[230448, 5993, 177, 4, 77, "Print",ExpressionUUID->"7b34f67f-8fba-48af-b0ed-15451510fb4d"],
+Cell[230628, 5999, 177, 4, 77, "Print",ExpressionUUID->"623b4ce0-9f63-42a3-8876-d6b85ec72c96"],
+Cell[230808, 6005, 175, 4, 77, "Print",ExpressionUUID->"cb3d7a50-1858-48a8-87fe-3688d64f6d13"],
+Cell[230986, 6011, 175, 4, 77, "Print",ExpressionUUID->"7ae44efa-2f18-4931-8be8-6fdc197f682d"],
+Cell[231164, 6017, 175, 4, 77, "Print",ExpressionUUID->"d5254600-0275-4b7f-b5cd-5c6e827a07ff"],
+Cell[231342, 6023, 177, 4, 77, "Print",ExpressionUUID->"485a1a92-0478-4c57-849e-811f426d41bd"],
+Cell[231522, 6029, 175, 4, 77, "Print",ExpressionUUID->"df1ff040-35ab-44d1-9c3a-4a5a3772590d"],
+Cell[231700, 6035, 175, 4, 77, "Print",ExpressionUUID->"fce9d9aa-f1a0-4985-bd1b-2b882e14335f"],
+Cell[231878, 6041, 175, 4, 77, "Print",ExpressionUUID->"06f30b07-7add-49c4-8463-b755584eb43b"],
+Cell[232056, 6047, 174, 4, 77, "Print",ExpressionUUID->"93c22934-1939-4865-9f9d-4e11565eee9d"],
+Cell[232233, 6053, 177, 4, 77, "Print",ExpressionUUID->"003e7603-d839-4c4f-9b4e-ab7dabc24820"],
+Cell[232413, 6059, 175, 4, 77, "Print",ExpressionUUID->"43504828-066f-444b-a2f0-565038113fcf"],
+Cell[232591, 6065, 177, 4, 77, "Print",ExpressionUUID->"e48b0879-c226-4a6c-a6d3-3c616134e073"],
+Cell[232771, 6071, 177, 4, 77, "Print",ExpressionUUID->"3efbc823-c03f-4fd6-8e13-c8c4531e99ed"],
+Cell[232951, 6077, 175, 4, 77, "Print",ExpressionUUID->"a1a87166-0177-42c5-a6ba-56298cc8a77a"],
+Cell[233129, 6083, 174, 4, 77, "Print",ExpressionUUID->"15f9bc51-203e-4507-98e7-476691ca1f7a"],
+Cell[233306, 6089, 177, 4, 77, "Print",ExpressionUUID->"321cc4bf-c073-46bb-b2f5-cf84a42f1933"],
+Cell[233486, 6095, 175, 4, 77, "Print",ExpressionUUID->"e78112c1-64a4-46f2-ad85-f1a9dde2f13e"],
+Cell[233664, 6101, 177, 4, 77, "Print",ExpressionUUID->"5e60ba3d-4cd5-4a7c-af74-fcc16ef8d7d0"],
+Cell[233844, 6107, 175, 4, 77, "Print",ExpressionUUID->"5d6144fe-7510-4411-a26a-fdda8dca9da9"],
+Cell[234022, 6113, 177, 4, 77, "Print",ExpressionUUID->"eafa4e99-b51d-4e83-a60a-0fa4ccb2a2be"]
 }, Open  ]]
 }, Open  ]]
 }, Closed]]
 }, Open  ]]
-}, Closed]],
+}, Open  ]],
 Cell[CellGroupData[{
-Cell[234375, 6128, 159, 3, 58, "Section",ExpressionUUID->"7913552e-0f6e-4573-9e3b-c1ba5594b326"],
+Cell[234284, 6126, 159, 3, 56, "Section",ExpressionUUID->"7913552e-0f6e-4573-9e3b-c1ba5594b326"],
 Cell[CellGroupData[{
-Cell[234559, 6135, 201, 3, 31, "Input",ExpressionUUID->"cdb01dcb-43f1-4602-8e88-85e2ea5cbdcc"],
+Cell[234468, 6133, 201, 3, 31, "Input",ExpressionUUID->"cdb01dcb-43f1-4602-8e88-85e2ea5cbdcc"],
 Cell[CellGroupData[{
-Cell[234785, 6142, 708, 12, 48, "Print",ExpressionUUID->"fa3b1a97-c88a-46b9-a58f-744e133e5d2d"],
-Cell[235496, 6156, 654, 11, 27, "Print",ExpressionUUID->"fc69bcdc-7d73-461a-a955-37bc7d96bf79"],
-Cell[236153, 6169, 658, 11, 27, "Print",ExpressionUUID->"524c017e-e647-41c6-9a2b-468ac434689b"],
-Cell[236814, 6182, 665, 11, 27, "Print",ExpressionUUID->"98e70419-8556-497e-89af-f4c3b34dbe45"],
-Cell[237482, 6195, 723, 12, 27, "Print",ExpressionUUID->"e5d9b1ca-0470-4571-8e21-5408370f94f3"]
+Cell[234694, 6140, 708, 12, 48, "Print",ExpressionUUID->"fa3b1a97-c88a-46b9-a58f-744e133e5d2d"],
+Cell[235405, 6154, 654, 11, 27, "Print",ExpressionUUID->"fc69bcdc-7d73-461a-a955-37bc7d96bf79"],
+Cell[236062, 6167, 658, 11, 27, "Print",ExpressionUUID->"524c017e-e647-41c6-9a2b-468ac434689b"],
+Cell[236723, 6180, 665, 11, 27, "Print",ExpressionUUID->"98e70419-8556-497e-89af-f4c3b34dbe45"],
+Cell[237391, 6193, 723, 12, 27, "Print",ExpressionUUID->"e5d9b1ca-0470-4571-8e21-5408370f94f3"]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[238254, 6213, 281, 7, 31, "Input",ExpressionUUID->"dbd8d8c1-b5f1-4eaf-8bfb-e36a12713974"],
-Cell[238538, 6222, 198, 5, 36, "Output",ExpressionUUID->"486ee3d5-0553-4c4e-b7f1-6fc22db751a7"]
+Cell[238163, 6211, 281, 7, 31, "Input",ExpressionUUID->"dbd8d8c1-b5f1-4eaf-8bfb-e36a12713974"],
+Cell[238447, 6220, 198, 5, 36, "Output",ExpressionUUID->"486ee3d5-0553-4c4e-b7f1-6fc22db751a7"]
 }, Open  ]],
-Cell[238751, 6230, 1431, 38, 79, "Code",ExpressionUUID->"b30a1b36-9a59-41f4-8c5f-b2a2d50604a7"],
-Cell[240185, 6270, 1244, 32, 56, "Input",ExpressionUUID->"c4520a97-3b37-42d8-81da-ff6729a6ffb0"],
+Cell[238660, 6228, 1431, 38, 79, "Code",ExpressionUUID->"b30a1b36-9a59-41f4-8c5f-b2a2d50604a7"],
+Cell[240094, 6268, 1244, 32, 56, "Input",ExpressionUUID->"c4520a97-3b37-42d8-81da-ff6729a6ffb0"],
 Cell[CellGroupData[{
-Cell[241454, 6306, 1181, 24, 56, "Input",ExpressionUUID->"ab1d7b22-85d6-46fb-a671-2d35b2803f78"],
-Cell[242638, 6332, 1503, 41, 36, "Output",ExpressionUUID->"938491ed-40b4-44a0-a094-d009a672531b"],
-Cell[244144, 6375, 424, 8, 36, "Output",ExpressionUUID->"b2f527e6-daa6-4390-bf83-80b87c4413ce"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[244605, 6388, 664, 17, 56, "Input",ExpressionUUID->"ee4b5200-0654-4297-afa2-59e1eebd0c4d"],
-Cell[245272, 6407, 1334, 37, 36, "Output",ExpressionUUID->"c4d064ed-f1ab-4683-b800-2f8852cd395c"],
-Cell[246609, 6446, 204, 4, 36, "Output",ExpressionUUID->"f8588238-9b5c-4135-9680-8c2731d19726"]
-}, Open  ]],
-Cell[246828, 6453, 422, 13, 31, "Input",ExpressionUUID->"48cfd36c-cd39-4b6b-9c52-8f0a202f8e41"],
-Cell[CellGroupData[{
-Cell[247275, 6470, 1173, 32, 78, "Input",ExpressionUUID->"261fbb03-b8c3-4fee-9078-1d0c02e09c5f"],
-Cell[248451, 6504, 2254, 64, 60, "Output",ExpressionUUID->"1f8c840e-056d-40a2-92f3-43deb11c3000"],
-Cell[250708, 6570, 403, 8, 36, "Output",ExpressionUUID->"33d5b0a4-e4c6-4d44-b306-0f521e6f2cc0"],
-Cell[251114, 6580, 358, 6, 36, "Output",ExpressionUUID->"48ab6462-cc4d-4ed6-969e-a2786a637bb1"]
+Cell[241363, 6304, 1178, 23, 56, "Input",ExpressionUUID->"ab1d7b22-85d6-46fb-a671-2d35b2803f78"],
+Cell[242544, 6329, 1485, 38, 36, "Output",ExpressionUUID->"938491ed-40b4-44a0-a094-d009a672531b"],
+Cell[244032, 6369, 424, 8, 36, "Output",ExpressionUUID->"b2f527e6-daa6-4390-bf83-80b87c4413ce"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[251509, 6591, 912, 26, 56, "Input",ExpressionUUID->"4d3a75c8-8b13-47eb-9761-0f4508d5f848"],
-Cell[252424, 6619, 545, 14, 36, "Output",ExpressionUUID->"ca74db15-2307-496e-8398-d4107fd937eb"],
-Cell[252972, 6635, 202, 3, 36, "Output",ExpressionUUID->"cf823c33-f20d-466d-8551-e16c11ba1719"]
+Cell[244493, 6382, 661, 16, 56, "Input",ExpressionUUID->"ee4b5200-0654-4297-afa2-59e1eebd0c4d"],
+Cell[245157, 6400, 1334, 37, 36, "Output",ExpressionUUID->"c4d064ed-f1ab-4683-b800-2f8852cd395c"],
+Cell[246494, 6439, 204, 4, 36, "Output",ExpressionUUID->"f8588238-9b5c-4135-9680-8c2731d19726"]
 }, Open  ]],
-Cell[253189, 6641, 147, 3, 56, "Input",ExpressionUUID->"19e58bd6-c681-4206-adc6-b65639e0f15a"],
+Cell[246713, 6446, 422, 13, 31, "Input",ExpressionUUID->"48cfd36c-cd39-4b6b-9c52-8f0a202f8e41"],
 Cell[CellGroupData[{
-Cell[253361, 6648, 156, 3, 31, "Input",ExpressionUUID->"1c603994-f0e6-436d-9333-6b055e7c4bc5"],
-Cell[253520, 6653, 1613, 42, 60, "Output",ExpressionUUID->"72a22998-79fd-41fe-90cf-c455652024ba"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[255170, 6700, 738, 20, 100, "Input",ExpressionUUID->"1eb83e3a-4f58-4f65-bad6-180fedee447a"],
-Cell[255911, 6722, 369, 9, 52, "Output",ExpressionUUID->"2173155c-2697-43c0-8623-68d5948c0f58"],
-Cell[256283, 6733, 413, 11, 36, "Output",ExpressionUUID->"e8adebf3-b2b9-4412-88a3-21fe7548e582"]
+Cell[247160, 6463, 1170, 31, 78, "Input",ExpressionUUID->"261fbb03-b8c3-4fee-9078-1d0c02e09c5f"],
+Cell[248333, 6496, 2188, 53, 60, "Output",ExpressionUUID->"1f8c840e-056d-40a2-92f3-43deb11c3000"],
+Cell[250524, 6551, 403, 8, 36, "Output",ExpressionUUID->"33d5b0a4-e4c6-4d44-b306-0f521e6f2cc0"],
+Cell[250930, 6561, 358, 6, 36, "Output",ExpressionUUID->"48ab6462-cc4d-4ed6-969e-a2786a637bb1"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[256733, 6749, 218, 4, 31, "Input",ExpressionUUID->"9db71011-803b-4ab1-ac3f-11ea33eb099b"],
-Cell[256954, 6755, 168, 2, 36, "Output",ExpressionUUID->"3936bfa0-daa6-40cc-9add-de13f9c792a6"]
+Cell[251325, 6572, 909, 25, 56, "Input",ExpressionUUID->"4d3a75c8-8b13-47eb-9761-0f4508d5f848"],
+Cell[252237, 6599, 541, 13, 36, "Output",ExpressionUUID->"ca74db15-2307-496e-8398-d4107fd937eb"],
+Cell[252781, 6614, 202, 3, 36, "Output",ExpressionUUID->"cf823c33-f20d-466d-8551-e16c11ba1719"]
 }, Open  ]],
-Cell[257137, 6760, 177, 3, 31, "Input",ExpressionUUID->"e32052a6-eaf7-a84b-afe2-9e1a5799b3ef"],
+Cell[252998, 6620, 147, 3, 56, "Input",ExpressionUUID->"19e58bd6-c681-4206-adc6-b65639e0f15a"],
 Cell[CellGroupData[{
-Cell[257339, 6767, 472, 10, 78, "Input",ExpressionUUID->"28be093b-8c75-4575-b886-ed4c2268ec21"],
-Cell[257814, 6779, 8406, 259, 464, "Output",ExpressionUUID->"e5330278-e8ed-4c80-8365-752e1e8571d4"]
-}, Open  ]],
-Cell[266235, 7041, 712, 16, 124, "Input",ExpressionUUID->"295861dd-cca8-475b-a845-c9fd9e623799"],
-Cell[266950, 7059, 405, 6, 31, "Input",ExpressionUUID->"ceb61f56-0159-5e49-a4d5-79dda151452f"],
-Cell[CellGroupData[{
-Cell[267380, 7069, 943, 19, 31, "Input",ExpressionUUID->"5d4487b0-20a7-4f0a-8e90-705b92b640b7"],
-Cell[268326, 7090, 4833, 99, 150, "Output",ExpressionUUID->"c179cb74-c4fb-4972-b587-9eebd5a718f0"]
-}, Open  ]],
-Cell[273174, 7192, 655, 15, 56, "Input",ExpressionUUID->"e842e6b7-9694-224d-b51d-3465a76be06c"],
-Cell[CellGroupData[{
-Cell[273854, 7211, 344, 6, 56, "Input",ExpressionUUID->"6d523e3e-6308-a34f-9636-dc9552080922"],
-Cell[274201, 7219, 6008, 165, 217, "Output",ExpressionUUID->"9f956646-704a-5a40-8cf0-37806aaf0665"],
-Cell[280212, 7386, 199, 3, 36, "Output",ExpressionUUID->"5fe290fb-cb2c-3542-bf7d-8b756dc83e3e"]
+Cell[253170, 6627, 156, 3, 31, "Input",ExpressionUUID->"1c603994-f0e6-436d-9333-6b055e7c4bc5"],
+Cell[253329, 6632, 1613, 42, 60, "Output",ExpressionUUID->"72a22998-79fd-41fe-90cf-c455652024ba"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[280448, 7394, 347, 6, 56, "Input",ExpressionUUID->"43804c85-de41-9046-b6d0-6d8cf0e830be"],
-Cell[280798, 7402, 18022, 496, 710, "Output",ExpressionUUID->"e4af9657-e8dd-634f-a070-775a9489cb5c"],
-Cell[298823, 7900, 202, 3, 36, "Output",ExpressionUUID->"e642b11d-1322-d24d-99f6-3bb9070ded1c"]
-}, Open  ]],
-Cell[299040, 7906, 1147, 31, 124, "Input",ExpressionUUID->"e593df63-74d9-4a4c-a2e2-f808f2ce3cf7"],
-Cell[CellGroupData[{
-Cell[300212, 7941, 183, 2, 31, "Input",ExpressionUUID->"ec76493d-3eee-6e44-998a-6acc67631974"],
-Cell[300398, 7945, 7481, 153, 310, "Output",ExpressionUUID->"b69f2027-4eaa-4843-bac9-7513db805329"]
+Cell[254979, 6679, 735, 19, 100, "Input",ExpressionUUID->"1eb83e3a-4f58-4f65-bad6-180fedee447a"],
+Cell[255717, 6700, 369, 9, 52, "Output",ExpressionUUID->"2173155c-2697-43c0-8623-68d5948c0f58"],
+Cell[256089, 6711, 413, 11, 36, "Output",ExpressionUUID->"e8adebf3-b2b9-4412-88a3-21fe7548e582"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[307916, 8103, 267, 6, 31, "Input",ExpressionUUID->"f510ea3d-47a0-4da8-8833-3ac25ec875bd"],
-Cell[308186, 8111, 10608, 222, 968, "Output",ExpressionUUID->"557149a3-58a7-4a23-bd23-af89f27860c8"]
+Cell[256539, 6727, 218, 4, 31, "Input",ExpressionUUID->"9db71011-803b-4ab1-ac3f-11ea33eb099b"],
+Cell[256760, 6733, 168, 2, 36, "Output",ExpressionUUID->"3936bfa0-daa6-40cc-9add-de13f9c792a6"]
+}, Open  ]],
+Cell[256943, 6738, 177, 3, 31, "Input",ExpressionUUID->"e32052a6-eaf7-a84b-afe2-9e1a5799b3ef"],
+Cell[CellGroupData[{
+Cell[257145, 6745, 472, 10, 78, "Input",ExpressionUUID->"28be093b-8c75-4575-b886-ed4c2268ec21"],
+Cell[257620, 6757, 8406, 259, 464, "Output",ExpressionUUID->"e5330278-e8ed-4c80-8365-752e1e8571d4"]
+}, Open  ]],
+Cell[266041, 7019, 712, 16, 124, "Input",ExpressionUUID->"295861dd-cca8-475b-a845-c9fd9e623799"],
+Cell[266756, 7037, 405, 6, 31, "Input",ExpressionUUID->"ceb61f56-0159-5e49-a4d5-79dda151452f"],
+Cell[CellGroupData[{
+Cell[267186, 7047, 943, 19, 31, "Input",ExpressionUUID->"5d4487b0-20a7-4f0a-8e90-705b92b640b7"],
+Cell[268132, 7068, 4833, 99, 150, "Output",ExpressionUUID->"c179cb74-c4fb-4972-b587-9eebd5a718f0"]
+}, Open  ]],
+Cell[272980, 7170, 655, 15, 56, "Input",ExpressionUUID->"e842e6b7-9694-224d-b51d-3465a76be06c"],
+Cell[CellGroupData[{
+Cell[273660, 7189, 344, 6, 56, "Input",ExpressionUUID->"6d523e3e-6308-a34f-9636-dc9552080922"],
+Cell[274007, 7197, 6008, 165, 217, "Output",ExpressionUUID->"9f956646-704a-5a40-8cf0-37806aaf0665"],
+Cell[280018, 7364, 199, 3, 36, "Output",ExpressionUUID->"5fe290fb-cb2c-3542-bf7d-8b756dc83e3e"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[280254, 7372, 347, 6, 56, "Input",ExpressionUUID->"43804c85-de41-9046-b6d0-6d8cf0e830be"],
+Cell[280604, 7380, 18022, 496, 710, "Output",ExpressionUUID->"e4af9657-e8dd-634f-a070-775a9489cb5c"],
+Cell[298629, 7878, 202, 3, 36, "Output",ExpressionUUID->"e642b11d-1322-d24d-99f6-3bb9070ded1c"]
+}, Open  ]],
+Cell[298846, 7884, 1147, 31, 124, "Input",ExpressionUUID->"e593df63-74d9-4a4c-a2e2-f808f2ce3cf7"],
+Cell[CellGroupData[{
+Cell[300018, 7919, 183, 2, 31, "Input",ExpressionUUID->"ec76493d-3eee-6e44-998a-6acc67631974"],
+Cell[300204, 7923, 7481, 153, 310, "Output",ExpressionUUID->"b69f2027-4eaa-4843-bac9-7513db805329"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[307722, 8081, 267, 6, 31, "Input",ExpressionUUID->"f510ea3d-47a0-4da8-8833-3ac25ec875bd"],
+Cell[307992, 8089, 10608, 222, 968, "Output",ExpressionUUID->"557149a3-58a7-4a23-bd23-af89f27860c8"]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[318831, 8338, 261, 5, 27, "Input",ExpressionUUID->"598bc59f-1f3d-40e5-926c-41159dab808e"],
-Cell[319095, 8345, 885, 26, 62, "Output",ExpressionUUID->"7cd3a371-6124-4008-8c9b-3af61b7d04b6"]
+Cell[318637, 8316, 261, 5, 27, "Input",ExpressionUUID->"598bc59f-1f3d-40e5-926c-41159dab808e"],
+Cell[318901, 8323, 885, 26, 62, "Output",ExpressionUUID->"7cd3a371-6124-4008-8c9b-3af61b7d04b6"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[320017, 8376, 197, 4, 31, "Input",ExpressionUUID->"3b2c5822-0512-470e-8d78-b4910f7a6165"],
-Cell[320217, 8382, 924, 26, 63, "Output",ExpressionUUID->"df8c9c07-ffe7-4aa6-bdef-0d43c2022c1c"]
+Cell[319823, 8354, 197, 4, 31, "Input",ExpressionUUID->"3b2c5822-0512-470e-8d78-b4910f7a6165"],
+Cell[320023, 8360, 924, 26, 63, "Output",ExpressionUUID->"df8c9c07-ffe7-4aa6-bdef-0d43c2022c1c"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[321178, 8413, 667, 17, 31, "Input",ExpressionUUID->"ebc881b3-79d6-4590-a59f-807fbc855ea8"],
-Cell[321848, 8432, 733, 15, 36, "Output",ExpressionUUID->"eb877932-c2dd-4661-8404-e3ca9f21d74a"]
+Cell[320984, 8391, 667, 17, 31, "Input",ExpressionUUID->"ebc881b3-79d6-4590-a59f-807fbc855ea8"],
+Cell[321654, 8410, 733, 15, 36, "Output",ExpressionUUID->"eb877932-c2dd-4661-8404-e3ca9f21d74a"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[322618, 8452, 12561, 354, 418, "Input",ExpressionUUID->"d7915227-4f1e-4323-bfcf-9df47ccaf4a2"],
-Cell[335182, 8808, 20330, 592, 588, "Output",ExpressionUUID->"b3d3ec2f-7efa-46f7-a358-fd50bcd18472"]
+Cell[322424, 8430, 12561, 354, 418, "Input",ExpressionUUID->"d7915227-4f1e-4323-bfcf-9df47ccaf4a2"],
+Cell[334988, 8786, 20330, 592, 588, "Output",ExpressionUUID->"b3d3ec2f-7efa-46f7-a358-fd50bcd18472"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[355549, 9405, 201, 3, 31, "Input",ExpressionUUID->"11c59fd9-b1db-40ba-8fc9-065d3a3508f1"],
+Cell[355355, 9383, 201, 3, 31, "Input",ExpressionUUID->"11c59fd9-b1db-40ba-8fc9-065d3a3508f1"],
 Cell[CellGroupData[{
-Cell[355775, 9412, 336, 6, 48, "Print",ExpressionUUID->"6c1ddfd2-fec6-41e5-aa7d-7f3c244c10be"],
-Cell[356114, 9420, 284, 5, 27, "Print",ExpressionUUID->"91562440-e615-4a2f-95b9-98329763443c"],
-Cell[356401, 9427, 287, 5, 27, "Print",ExpressionUUID->"527d6a07-8390-4194-96e2-b71a0607861b"],
-Cell[356691, 9434, 295, 5, 27, "Print",ExpressionUUID->"c5c8f6f5-3930-4a25-8516-bb1ace011d21"],
-Cell[356989, 9441, 314, 5, 27, "Print",ExpressionUUID->"b1d88090-5894-4ca9-a646-bcef5735da3e"]
+Cell[355581, 9390, 336, 6, 48, "Print",ExpressionUUID->"6c1ddfd2-fec6-41e5-aa7d-7f3c244c10be"],
+Cell[355920, 9398, 284, 5, 27, "Print",ExpressionUUID->"91562440-e615-4a2f-95b9-98329763443c"],
+Cell[356207, 9405, 287, 5, 27, "Print",ExpressionUUID->"527d6a07-8390-4194-96e2-b71a0607861b"],
+Cell[356497, 9412, 295, 5, 27, "Print",ExpressionUUID->"c5c8f6f5-3930-4a25-8516-bb1ace011d21"],
+Cell[356795, 9419, 314, 5, 27, "Print",ExpressionUUID->"b1d88090-5894-4ca9-a646-bcef5735da3e"]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[357352, 9452, 366, 8, 31, "Input",ExpressionUUID->"e7b328ba-426f-4d21-99ac-fb9d5bf97cce"],
-Cell[357721, 9462, 17250, 511, 492, "Output",ExpressionUUID->"c78216cb-06ba-4f3d-b6a3-c36d17641f6d"]
+Cell[357158, 9430, 367, 8, 31, "Input",ExpressionUUID->"e7b328ba-426f-4d21-99ac-fb9d5bf97cce"],
+Cell[357528, 9440, 17250, 511, 492, "Output",ExpressionUUID->"c78216cb-06ba-4f3d-b6a3-c36d17641f6d"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[375008, 9978, 227, 4, 31, "Input",ExpressionUUID->"ee3ee898-153b-4b57-ab94-0ebe2bfebd13"],
-Cell[375238, 9984, 49510, 1414, 1434, "Output",ExpressionUUID->"a63a1390-a1f4-43b8-a041-49a17e772705"]
+Cell[374815, 9956, 227, 4, 31, "Input",ExpressionUUID->"ee3ee898-153b-4b57-ab94-0ebe2bfebd13"],
+Cell[375045, 9962, 49510, 1414, 1434, "Output",ExpressionUUID->"a63a1390-a1f4-43b8-a041-49a17e772705"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[424785, 11403, 620, 16, 31, "Input",ExpressionUUID->"ddaaaaf0-a706-4565-a786-79de95c4b4a4"],
-Cell[425408, 11421, 529, 12, 36, "Output",ExpressionUUID->"d2c02e13-fb5a-482f-8d3f-10ea8d2c7489"]
+Cell[424592, 11381, 620, 16, 31, "Input",ExpressionUUID->"ddaaaaf0-a706-4565-a786-79de95c4b4a4"],
+Cell[425215, 11399, 529, 12, 36, "Output",ExpressionUUID->"d2c02e13-fb5a-482f-8d3f-10ea8d2c7489"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[425974, 11438, 3331, 85, 187, "Input",ExpressionUUID->"42330876-c466-4648-9f1a-01eb934d2274"],
-Cell[429308, 11525, 3701, 97, 122, "Output",ExpressionUUID->"22284f16-cdd9-4a79-b3c1-6e9c6958d18a"]
+Cell[425781, 11416, 3331, 85, 187, "Input",ExpressionUUID->"42330876-c466-4648-9f1a-01eb934d2274"],
+Cell[429115, 11503, 3701, 97, 122, "Output",ExpressionUUID->"22284f16-cdd9-4a79-b3c1-6e9c6958d18a"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[433046, 11627, 721, 19, 59, "Input",ExpressionUUID->"fc1286dc-33f8-4395-9082-b260ed374766"],
-Cell[433770, 11648, 1888, 52, 45, "Output",ExpressionUUID->"fd980a34-0c08-44fe-8597-1accdf13a6ea"],
-Cell[435661, 11702, 1993, 51, 66, "Output",ExpressionUUID->"bd29faed-e266-4e2c-abfb-7bba530e70af"]
+Cell[432853, 11605, 721, 19, 59, "Input",ExpressionUUID->"fc1286dc-33f8-4395-9082-b260ed374766"],
+Cell[433577, 11626, 1888, 52, 45, "Output",ExpressionUUID->"fd980a34-0c08-44fe-8597-1accdf13a6ea"],
+Cell[435468, 11680, 1993, 51, 66, "Output",ExpressionUUID->"bd29faed-e266-4e2c-abfb-7bba530e70af"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[437691, 11758, 917, 23, 59, "Input",ExpressionUUID->"806e3ead-6cfd-49b3-bc3d-f84cfebc9628"],
-Cell[438611, 11783, 556, 13, 66, "Output",ExpressionUUID->"cd46b1b4-b83a-4941-baca-693e24b12424"],
-Cell[439170, 11798, 919, 23, 40, "Output",ExpressionUUID->"e251d45c-1675-4d21-8cb5-0257c33bae30"]
+Cell[437498, 11736, 917, 23, 59, "Input",ExpressionUUID->"806e3ead-6cfd-49b3-bc3d-f84cfebc9628"],
+Cell[438418, 11761, 556, 13, 66, "Output",ExpressionUUID->"cd46b1b4-b83a-4941-baca-693e24b12424"],
+Cell[438977, 11776, 919, 23, 40, "Output",ExpressionUUID->"e251d45c-1675-4d21-8cb5-0257c33bae30"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[440126, 11826, 413, 10, 31, "Input",ExpressionUUID->"bb8757e3-a1bf-4b01-977d-105f3efb9dc5"],
-Cell[440542, 11838, 213, 4, 52, "Output",ExpressionUUID->"988e8203-29f9-4d69-8bbf-480d9661502c"]
+Cell[439933, 11804, 413, 10, 31, "Input",ExpressionUUID->"bb8757e3-a1bf-4b01-977d-105f3efb9dc5"],
+Cell[440349, 11816, 213, 4, 52, "Output",ExpressionUUID->"988e8203-29f9-4d69-8bbf-480d9661502c"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[440792, 11847, 264, 6, 31, "Input",ExpressionUUID->"73c99062-834e-4c6d-b014-0f8b8a46f31d"],
-Cell[441059, 11855, 320, 8, 66, "Output",ExpressionUUID->"a0084f4f-6ca3-4af8-bc31-089a53b02085"]
+Cell[440599, 11825, 264, 6, 31, "Input",ExpressionUUID->"73c99062-834e-4c6d-b014-0f8b8a46f31d"],
+Cell[440866, 11833, 320, 8, 66, "Output",ExpressionUUID->"a0084f4f-6ca3-4af8-bc31-089a53b02085"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[441416, 11868, 1467, 40, 81, "Input",ExpressionUUID->"48208da4-6482-4f6a-96bf-fcb81c24d74f"],
-Cell[442886, 11910, 3291, 90, 114, "Output",ExpressionUUID->"e0bb2e30-9c83-49a9-9231-330183254d3f"],
-Cell[446180, 12002, 490, 11, 36, "Output",ExpressionUUID->"54897e7d-6087-427d-8671-513409efa2e1"]
+Cell[441223, 11846, 1467, 40, 81, "Input",ExpressionUUID->"48208da4-6482-4f6a-96bf-fcb81c24d74f"],
+Cell[442693, 11888, 3291, 90, 114, "Output",ExpressionUUID->"e0bb2e30-9c83-49a9-9231-330183254d3f"],
+Cell[445987, 11980, 490, 11, 36, "Output",ExpressionUUID->"54897e7d-6087-427d-8671-513409efa2e1"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[446707, 12018, 295, 6, 31, "Input",ExpressionUUID->"51815755-44dc-42c6-943d-cac406ffec25"],
-Cell[447005, 12026, 13906, 316, 276, "Output",ExpressionUUID->"874113cd-bda7-44f1-9a54-a4810e4bd164"]
+Cell[446514, 11996, 295, 6, 31, "Input",ExpressionUUID->"51815755-44dc-42c6-943d-cac406ffec25"],
+Cell[446812, 12004, 13906, 316, 276, "Output",ExpressionUUID->"874113cd-bda7-44f1-9a54-a4810e4bd164"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[460948, 12347, 2288, 60, 125, "Input",ExpressionUUID->"1e9cee2e-b4d1-4da9-a15e-8f63da7d3ece"],
-Cell[463239, 12409, 9544, 243, 306, "Output",ExpressionUUID->"edb02eb8-34f4-40fb-9d2c-b76422600fe8"],
-Cell[472786, 12654, 2409, 60, 62, "Output",ExpressionUUID->"a1bc2648-643d-4093-b280-6aff5815a4a3"],
-Cell[475198, 12716, 1192, 29, 59, "Output",ExpressionUUID->"65e3a060-71b1-483b-be81-7f8eaeaa1c7f"],
-Cell[476393, 12747, 2849, 73, 64, "Output",ExpressionUUID->"58946538-7701-4ca1-bcb8-4640378c7d5f"]
+Cell[460755, 12325, 2288, 60, 125, "Input",ExpressionUUID->"1e9cee2e-b4d1-4da9-a15e-8f63da7d3ece"],
+Cell[463046, 12387, 9544, 243, 306, "Output",ExpressionUUID->"edb02eb8-34f4-40fb-9d2c-b76422600fe8"],
+Cell[472593, 12632, 2409, 60, 62, "Output",ExpressionUUID->"a1bc2648-643d-4093-b280-6aff5815a4a3"],
+Cell[475005, 12694, 1192, 29, 59, "Output",ExpressionUUID->"65e3a060-71b1-483b-be81-7f8eaeaa1c7f"],
+Cell[476200, 12725, 2849, 73, 64, "Output",ExpressionUUID->"58946538-7701-4ca1-bcb8-4640378c7d5f"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[479279, 12825, 993, 26, 78, "Input",ExpressionUUID->"d0e59b80-80bd-46e6-abc5-6b6e5aab971a"],
-Cell[480275, 12853, 15916, 369, 665, "Output",ExpressionUUID->"69b3caad-1efb-409f-a290-f6014ccf3f1c"],
-Cell[496194, 13224, 3208, 80, 161, "Output",ExpressionUUID->"f52889ee-cc2a-4a9a-9065-2d3594e71058"],
-Cell[499405, 13306, 2542, 65, 114, "Output",ExpressionUUID->"8657b1e6-b369-419c-b510-559a8d3356f1"]
+Cell[479086, 12803, 993, 26, 78, "Input",ExpressionUUID->"d0e59b80-80bd-46e6-abc5-6b6e5aab971a"],
+Cell[480082, 12831, 15916, 369, 665, "Output",ExpressionUUID->"69b3caad-1efb-409f-a290-f6014ccf3f1c"],
+Cell[496001, 13202, 3208, 80, 161, "Output",ExpressionUUID->"f52889ee-cc2a-4a9a-9065-2d3594e71058"],
+Cell[499212, 13284, 2542, 65, 114, "Output",ExpressionUUID->"8657b1e6-b369-419c-b510-559a8d3356f1"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[501984, 13376, 473, 10, 31, "Input",ExpressionUUID->"265543b2-38c0-4439-9372-cd69c7be9245"],
-Cell[502460, 13388, 13762, 406, 424, "Output",ExpressionUUID->"740148ad-9e94-47de-b908-44038b3ef83d"]
+Cell[501791, 13354, 473, 10, 31, "Input",ExpressionUUID->"265543b2-38c0-4439-9372-cd69c7be9245"],
+Cell[502267, 13366, 13762, 406, 424, "Output",ExpressionUUID->"740148ad-9e94-47de-b908-44038b3ef83d"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[516259, 13799, 2153, 59, 78, "Input",ExpressionUUID->"52ed40b7-358e-45c8-bc78-1bedc44d1069"],
-Cell[518415, 13860, 3850, 123, 77, "Output",ExpressionUUID->"33df843a-f46f-4647-aaac-6d1d347633b7"],
-Cell[522268, 13985, 378, 6, 36, "Output",ExpressionUUID->"ae84f6a5-8ff6-4328-8f0a-9d813bdbaa10"]
+Cell[516066, 13777, 2153, 59, 78, "Input",ExpressionUUID->"52ed40b7-358e-45c8-bc78-1bedc44d1069"],
+Cell[518222, 13838, 3850, 123, 77, "Output",ExpressionUUID->"33df843a-f46f-4647-aaac-6d1d347633b7"],
+Cell[522075, 13963, 378, 6, 36, "Output",ExpressionUUID->"ae84f6a5-8ff6-4328-8f0a-9d813bdbaa10"]
 }, Open  ]]
 }, Closed]]
 }

--- a/match2fit.wl
+++ b/match2fit.wl
@@ -273,7 +273,7 @@ Continue[]];
 data]
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*MMEFT conventions*)
 
 
@@ -323,7 +323,7 @@ ret={Symbol[SymbolName[lam]]->Normal[Series[solutions[[2,1,2]],{onelooporder,0,1
 ret]
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*SMEFiT conventions*)
 
 
@@ -356,7 +356,9 @@ Symbol[SymbolName[\[Phi]q1]]][3,3]-Subscript[Symbol[SymbolName[wwC]],Symbol[Symb
 {Symbol[SymbolName[wwCQt8]],Subscript[Symbol[SymbolName[wwC]],Symbol[SymbolName[qu8]]][3,3,3,3]},{Symbol[SymbolName[wwCtt1]],Subscript[Symbol[SymbolName[wwC]],Symbol[SymbolName[uu]]][3,3,3,3]},
 {Symbol[SymbolName[wwCll]],Subscript[Symbol[SymbolName[wwC]],Symbol[SymbolName[ll]]][1,2,2,1]},{Symbol[SymbolName[wwCll1111]],Subscript[Symbol[SymbolName[wwC]],Symbol[SymbolName[ll]]][1,1,1,1]},
 {Symbol[SymbolName[wwCb\[CurlyPhi]]],Subscript[Symbol[SymbolName[wwC]],Symbol[SymbolName[d\[Phi]]]][3,3]},{Symbol[SymbolName[wwCt\[CurlyPhi]]],Subscript[Symbol[SymbolName[wwC]],Symbol[SymbolName[u\[Phi]]]][3,3]},
-{Symbol[SymbolName[wwCtG]],Subscript[Symbol[SymbolName[wwC]],Symbol[SymbolName[uG]]][3,3]},{Symbol[SymbolName[wwCc\[CurlyPhi]]],Subscript[Symbol[SymbolName[wwC]],Symbol[SymbolName[u\[Phi]]]][2,2]},
+{Symbol[SymbolName[wwCtG]],Subscript[Symbol[SymbolName[wwC]],Symbol[SymbolName[uG]]][3,3]/Symbol[SymbolName[g3]]
+
+},{Symbol[SymbolName[wwCc\[CurlyPhi]]],Subscript[Symbol[SymbolName[wwC]],Symbol[SymbolName[u\[Phi]]]][2,2]},
 {Symbol[SymbolName[wwC\[Tau]\[CurlyPhi]]],Subscript[Symbol[SymbolName[wwC]],Symbol[SymbolName[e\[Phi]]]][3,3]},
 {Symbol[SymbolName[wwC\[Mu]\[CurlyPhi]]],Subscript[Symbol[SymbolName[wwC]],Symbol[SymbolName[e\[Phi]]]][2,2]},
 {Symbol[SymbolName[wwCtW]],Subscript[Symbol[SymbolName[wwC]],Symbol[SymbolName[uW]]][3,3]},
@@ -736,11 +738,11 @@ allSol,
 Print["All conditions satisfied trivially."];{{AA->AA}}]];
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*SM numerical inputs*)
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*Gauge and Higgs parameters*)
 
 
@@ -1557,7 +1559,7 @@ matcher[directory_,model_,looplevel_,OptionsPattern[]]:=Block[{aux},
 matcherMMEFT[directory,model,looplevel,OptionValue["QGRAFPath"]]];
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*UV parameters recognition*)
 
 

--- a/sample_cards/1LoopMatching_collection/Mass_scans/SMEFiT_runcard_MassScan_1LoopMatching_Mod_T1_UVcoup_1_1Loop.yaml
+++ b/sample_cards/1LoopMatching_collection/Mass_scans/SMEFiT_runcard_MassScan_1LoopMatching_Mod_T1_UVcoup_1_1Loop.yaml
@@ -332,7 +332,7 @@ coefficients:
   OtG:
     constrain:
     - m:
-      - 0.0016731120783798807
+      - 0.0013745584117580562
       - -2
     max: 100
     min: -100
@@ -755,6 +755,8 @@ datasets:
   order: NLO_QCD
 - name: ATLAS_tttt_13TeV_slep_inc
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj
+  order: LO
 - name: ATLAS_SSinc_RunII_proj
   order: NLO_QCD
 - name: ATLAS_STXS_runII_13TeV_uncor_proj
@@ -811,8 +813,6 @@ datasets:
   order: NLO_QCD
 - name: CMS_tW_13TeV_slep_inc_proj
   order: NLO_QCD
-- name: CMS_tZ_13TeV_2016_inc_proj
-  order: NLO_QCD
 - name: CMS_tZ_13TeV_pTt_uncor_proj
   order: NLO_QCD
 - name: CMS_t_tch_13TeV_2019_diff_Yt_proj
@@ -851,6 +851,12 @@ datasets:
   order: NLO_QCD
 - name: HLLHC_tt_13TeV_asy
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj_proj
+  order: LO
+- name: HLLHC_H_14TeV_Snowmass
+  order: LO
+- name: HLLHC_H_14TeV_2025
+  order: LO
 - name: CEPC_161_ww_leptonic_optim_obs
   order: LO
 - name: CEPC_161_ww_semilep_optim_obs
@@ -906,6 +912,8 @@ datasets:
 - name: CEPC_zh_gg_240GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_240GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_240GeV
   order: NLO_EW
 - name: CEPC_365_tt_optim_obs
   order: LO
@@ -966,6 +974,8 @@ datasets:
 - name: CEPC_zh_gg_365GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_365GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_365GeV
   order: NLO_EW
 - name: CEPC_Wwidth
   order: LO
@@ -1059,8 +1069,6 @@ datasets:
   order: LO
 - name: FCCee_161_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_161GeV
-  order: LO
 - name: FCCee_ww_161GeV
   order: LO
 - name: FCCee_240_H_HADR
@@ -1069,7 +1077,7 @@ datasets:
   order: LO
 - name: FCCee_240_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_240GeV
+- name: FCCee_Brw
   order: LO
 - name: FCCee_Rb_240GeV
   order: LO
@@ -1085,15 +1093,13 @@ datasets:
   order: LO
 - name: FCCee_ee_Afb_240GeV
   order: LO
+- name: FCCee_ee_240GeV
+  order: LO
 - name: FCCee_mumu_Afb_240GeV
   order: LO
 - name: FCCee_sigmaHad_240GeV
   order: LO
 - name: FCCee_tautau_Afb_240GeV
-  order: LO
-- name: FCCee_vvh_240GeV
-  order: LO
-- name: FCCee_vvh_bb_240GeV
   order: LO
 - name: FCCee_ww_240GeV
   order: LO
@@ -1107,13 +1113,9 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_aa_240GeV
   order: NLO_EW
-- name: FCCee_zh_bb_240GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_240GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_240GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_240GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_240GeV
   order: NLO_EW
 - name: FCCee_365_H_HADR
   order: NLO_EW_only_for_ZH
@@ -1122,8 +1124,6 @@ datasets:
 - name: FCCee_365_ww_leptonic_optim_obs
   order: LO
 - name: FCCee_365_ww_semilep_optim_obs
-  order: LO
-- name: FCCee_Brw_365GeV
   order: LO
 - name: FCCee_Rb_365GeV
   order: LO
@@ -1137,27 +1137,23 @@ datasets:
   order: LO
 - name: FCCee_cc_Afb_365GeV
   order: LO
+- name: FCCee_mumu_Afb_365GeV
+  order: LO
 - name: FCCee_ee_Afb_365GeV
   order: LO
-- name: FCCee_mumu_Afb_365GeV
+- name: FCCee_ee_365GeV
   order: LO
 - name: FCCee_sigmaHad_365GeV
   order: LO
 - name: FCCee_tautau_Afb_365GeV
   order: LO
-- name: FCCee_vvh_365GeV
-  order: LO
 - name: FCCee_vvh_WW_365GeV
   order: LO
 - name: FCCee_vvh_ZZ_365GeV
   order: LO
+- name: FCCee_vvh_aZ_365GeV
+  order: LO
 - name: FCCee_vvh_aa_365GeV
-  order: LO
-- name: FCCee_vvh_bb_365GeV
-  order: LO
-- name: FCCee_vvh_cc_365GeV
-  order: LO
-- name: FCCee_vvh_gg_365GeV
   order: LO
 - name: FCCee_vvh_tautau_365GeV
   order: LO
@@ -1169,21 +1165,375 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_ZZ_365GeV
   order: NLO_EW
+- name: FCCee_zh_aZ_365GeV
+  order: NLO_EW
 - name: FCCee_zh_aa_365GeV
   order: NLO_EW
-- name: FCCee_zh_bb_365GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_365GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_365GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_365GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_365GeV
   order: NLO_EW
 - name: FCCee_Wwidth
   order: LO
 - name: FCCee_Zdata
   order: LO
 - name: FCCee_alphaEW
+  order: LO
+- name: LCF_Zdata_GigaZ
+  order: LO
+- name: LCF_alphaEW_250GeV
+  order: LO
+- name: LCF_vvh_bb_250GeV
+  order: LO
+- name: LCF_zh_250GeV
+  order: NLO_EW
+- name: LCF_bb_250GeV
+  order: LO
+- name: LCF_ww_250GeV
+  order: LO
+- name: LCF_zh_aa_250GeV
+  order: NLO_EW
+- name: LCF_bb_Afb_250GeV
+  order: LO
+- name: LCF_Wwidth_250GeV
+  order: LO
+- name: LCF_zh_aZ_250GeV
+  order: NLO_EW
+- name: LCF_Brw_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_bb_250GeV
+  order: NLO_EW
+- name: LCF_cc_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_cc_250GeV
+  order: NLO_EW
+- name: LCF_cc_Afb_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_gg_250GeV
+  order: NLO_EW
+- name: LCF_ee_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_zh_mumu_250GeV
+  order: NLO_EW
+- name: LCF_ee_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_tautau_250GeV
+  order: NLO_EW
+- name: LCF_mumu_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_ww_250GeV
+  order: NLO_EW
+- name: LCF_mumu_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_zz_250GeV
+  order: NLO_EW
+- name: LCF_tautau_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_tautau_Afb_250GeV
+  order: LO
+- name: LCF_Zdata_250GeV
+  order: LO
+- name: LCF_Brw_350GeV
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_350GeV
+  order: LO
+- name: LCF_vvh_bb_350GeV
+  order: LO
+- name: LCF_vvh_cc_350GeV
+  order: LO
+- name: LCF_vvh_gg_350GeV
+  order: LO
+- name: LCF_vvh_mumu_350GeV
+  order: LO
+- name: LCF_vvh_tautau_350GeV
+  order: LO
+- name: LCF_vvh_ww_350GeV
+  order: LO
+- name: LCF_vvh_zz_350GeV
+  order: LO
+- name: LCF_ww_350GeV
+  order: LO
+- name: LCF_zh_350GeV
+  order: NLO_EW
+- name: LCF_zh_aa_350GeV
+  order: NLO_EW
+- name: LCF_zh_bb_350GeV
+  order: NLO_EW
+- name: LCF_zh_cc_350GeV
+  order: NLO_EW
+- name: LCF_zh_gg_350GeV
+  order: NLO_EW
+- name: LCF_zh_mumu_350GeV
+  order: NLO_EW
+- name: LCF_zh_tautau_350GeV
+  order: NLO_EW
+- name: LCF_zh_ww_350GeV
+  order: NLO_EW
+- name: LCF_zh_zz_350GeV
+  order: NLO_EW
+- name: LCF_bb_500GeV_4ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_4ab
+  order: LO
+- name: LCF_Brw_500GeV_4ab
+  order: LO
+- name: LCF_cc_500GeV_4ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_4ab
+  order: LO
+- name: LCF_ee_500GeV_4ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_4ab
+  order: LO
+- name: LCF_mumu_500GeV_4ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tautau_500GeV_4ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tth_500GeV_4ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_4ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_4ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_4ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_4ab
+  order: LO
+- name: LCF_vvhh_500GeV_4ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_4ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_4ab
+  order: LO
+- name: LCF_ww_500GeV_4ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_4ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_zh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_zh_ww_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_4ab
+  order: NLO_EW
+- name: LCF_bb_500GeV_8ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_8ab
+  order: LO
+- name: LCF_Brw_500GeV_8ab
+  order: LO
+- name: LCF_cc_500GeV_8ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_8ab
+  order: LO
+- name: LCF_ee_500GeV_8ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_8ab
+  order: LO
+- name: LCF_mumu_500GeV_8ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tautau_500GeV_8ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tth_500GeV_8ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_8ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_8ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_8ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_8ab
+  order: LO
+- name: LCF_vvhh_500GeV_8ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_8ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_8ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_8ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_8ab
+  order: LO
+- name: LCF_ww_500GeV_8ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_8ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_tautau_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_ww_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_8ab
+  order: NLO_EW
+- name: LCF_bb_1000GeV
+  order: LO
+- name: LCF_bb_Afb_1000GeV
+  order: LO
+- name: LCF_cc_1000GeV
+  order: LO
+- name: LCF_cc_Afb_1000GeV
+  order: LO
+- name: LCF_ee_1000GeV
+  order: LO
+- name: LCF_ee_Afb_1000GeV
+  order: LO
+- name: LCF_mumu_1000GeV
+  order: LO
+- name: LCF_mumu_Afb_1000GeV
+  order: LO
+- name: LCF_tautau_1000GeV
+  order: LO
+- name: LCF_tautau_Afb_1000GeV
+  order: LO
+- name: LCF_tth_1000GeV
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_vvh_aa_1000GeV
+  order: LO
+- name: LCF_vvh_bb_1000GeV
+  order: LO
+- name: LCF_vvh_cc_1000GeV
+  order: LO
+- name: LCF_vvh_gg_1000GeV
+  order: LO
+- name: LCF_vvhh_1000GeV
+  order: LO
+- name: LCF_vvh_mumu_1000GeV
+  order: LO
+- name: LCF_vvh_tautau_1000GeV
+  order: LO
+- name: LCF_vvh_ww_1000GeV
+  order: LO
+- name: LCF_vvh_zz_1000GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_pos20
   order: LO
 - name: LEP1_EWPOs_2006
   order: LO
@@ -1200,6 +1550,64 @@ datasets:
 - name: LEP_eeWW_198GeV
   order: LO
 - name: LEP_eeWW_206GeV
+  order: LO
+- name: LEP3_240_H_HADR
+  order: NLO_EW_only_for_ZH
+- name: LEP3_240_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_240_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Brw
+  order: LO
+- name: LEP3_Rb_240GeV
+  order: LO
+- name: LEP3_Rc_240GeV
+  order: LO
+- name: LEP3_Rmu_240GeV
+  order: LO
+- name: LEP3_Rtau_240GeV
+  order: LO
+- name: LEP3_bb_Afb_240GeV
+  order: LO
+- name: LEP3_cc_Afb_240GeV
+  order: LO
+- name: LEP3_ee_Afb_240GeV
+  order: LO
+- name: LEP3_ee_240GeV
+  order: LO
+- name: LEP3_mumu_Afb_240GeV
+  order: LO
+- name: LEP3_sigmaHad_240GeV
+  order: LO
+- name: LEP3_tautau_Afb_240GeV
+  order: LO
+- name: LEP3_ww_240GeV
+  order: LO
+- name: LEP3_zh_240GeV
+  order: NLO_EW
+- name: LEP3_zh_WW_240GeV
+  order: NLO_EW
+- name: LEP3_zh_ZZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aa_240GeV
+  order: NLO_EW
+- name: LEP3_zh_mumu_240GeV
+  order: NLO_EW
+- name: LEP3_zh_tautau_240GeV
+  order: NLO_EW
+- name: LEP3_ww_161GeV
+  order: LO
+- name: LEP3_161_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_161_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Wwidth
+  order: LO
+- name: LEP3_Zdata
+  order: LO
+- name: LEP3_alphaEW
   order: LO
 external_chi2:
   OptimalWW161:

--- a/sample_cards/1LoopMatching_collection/Mass_scans/SMEFiT_runcard_MassScan_1LoopMatching_Mod_T2_UVcoup_1_1Loop.yaml
+++ b/sample_cards/1LoopMatching_collection/Mass_scans/SMEFiT_runcard_MassScan_1LoopMatching_Mod_T2_UVcoup_1_1Loop.yaml
@@ -332,7 +332,7 @@ coefficients:
   OtG:
     constrain:
     - m:
-      - 0.00023901601119712584
+      - 0.00019636548739400804
       - -2
     max: 100
     min: -100
@@ -755,6 +755,8 @@ datasets:
   order: NLO_QCD
 - name: ATLAS_tttt_13TeV_slep_inc
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj
+  order: LO
 - name: ATLAS_SSinc_RunII_proj
   order: NLO_QCD
 - name: ATLAS_STXS_runII_13TeV_uncor_proj
@@ -811,8 +813,6 @@ datasets:
   order: NLO_QCD
 - name: CMS_tW_13TeV_slep_inc_proj
   order: NLO_QCD
-- name: CMS_tZ_13TeV_2016_inc_proj
-  order: NLO_QCD
 - name: CMS_tZ_13TeV_pTt_uncor_proj
   order: NLO_QCD
 - name: CMS_t_tch_13TeV_2019_diff_Yt_proj
@@ -851,6 +851,12 @@ datasets:
   order: NLO_QCD
 - name: HLLHC_tt_13TeV_asy
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj_proj
+  order: LO
+- name: HLLHC_H_14TeV_Snowmass
+  order: LO
+- name: HLLHC_H_14TeV_2025
+  order: LO
 - name: CEPC_161_ww_leptonic_optim_obs
   order: LO
 - name: CEPC_161_ww_semilep_optim_obs
@@ -906,6 +912,8 @@ datasets:
 - name: CEPC_zh_gg_240GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_240GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_240GeV
   order: NLO_EW
 - name: CEPC_365_tt_optim_obs
   order: LO
@@ -966,6 +974,8 @@ datasets:
 - name: CEPC_zh_gg_365GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_365GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_365GeV
   order: NLO_EW
 - name: CEPC_Wwidth
   order: LO
@@ -1059,8 +1069,6 @@ datasets:
   order: LO
 - name: FCCee_161_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_161GeV
-  order: LO
 - name: FCCee_ww_161GeV
   order: LO
 - name: FCCee_240_H_HADR
@@ -1069,7 +1077,7 @@ datasets:
   order: LO
 - name: FCCee_240_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_240GeV
+- name: FCCee_Brw
   order: LO
 - name: FCCee_Rb_240GeV
   order: LO
@@ -1085,15 +1093,13 @@ datasets:
   order: LO
 - name: FCCee_ee_Afb_240GeV
   order: LO
+- name: FCCee_ee_240GeV
+  order: LO
 - name: FCCee_mumu_Afb_240GeV
   order: LO
 - name: FCCee_sigmaHad_240GeV
   order: LO
 - name: FCCee_tautau_Afb_240GeV
-  order: LO
-- name: FCCee_vvh_240GeV
-  order: LO
-- name: FCCee_vvh_bb_240GeV
   order: LO
 - name: FCCee_ww_240GeV
   order: LO
@@ -1107,13 +1113,9 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_aa_240GeV
   order: NLO_EW
-- name: FCCee_zh_bb_240GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_240GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_240GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_240GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_240GeV
   order: NLO_EW
 - name: FCCee_365_H_HADR
   order: NLO_EW_only_for_ZH
@@ -1122,8 +1124,6 @@ datasets:
 - name: FCCee_365_ww_leptonic_optim_obs
   order: LO
 - name: FCCee_365_ww_semilep_optim_obs
-  order: LO
-- name: FCCee_Brw_365GeV
   order: LO
 - name: FCCee_Rb_365GeV
   order: LO
@@ -1137,27 +1137,23 @@ datasets:
   order: LO
 - name: FCCee_cc_Afb_365GeV
   order: LO
+- name: FCCee_mumu_Afb_365GeV
+  order: LO
 - name: FCCee_ee_Afb_365GeV
   order: LO
-- name: FCCee_mumu_Afb_365GeV
+- name: FCCee_ee_365GeV
   order: LO
 - name: FCCee_sigmaHad_365GeV
   order: LO
 - name: FCCee_tautau_Afb_365GeV
   order: LO
-- name: FCCee_vvh_365GeV
-  order: LO
 - name: FCCee_vvh_WW_365GeV
   order: LO
 - name: FCCee_vvh_ZZ_365GeV
   order: LO
+- name: FCCee_vvh_aZ_365GeV
+  order: LO
 - name: FCCee_vvh_aa_365GeV
-  order: LO
-- name: FCCee_vvh_bb_365GeV
-  order: LO
-- name: FCCee_vvh_cc_365GeV
-  order: LO
-- name: FCCee_vvh_gg_365GeV
   order: LO
 - name: FCCee_vvh_tautau_365GeV
   order: LO
@@ -1169,21 +1165,375 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_ZZ_365GeV
   order: NLO_EW
+- name: FCCee_zh_aZ_365GeV
+  order: NLO_EW
 - name: FCCee_zh_aa_365GeV
   order: NLO_EW
-- name: FCCee_zh_bb_365GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_365GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_365GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_365GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_365GeV
   order: NLO_EW
 - name: FCCee_Wwidth
   order: LO
 - name: FCCee_Zdata
   order: LO
 - name: FCCee_alphaEW
+  order: LO
+- name: LCF_Zdata_GigaZ
+  order: LO
+- name: LCF_alphaEW_250GeV
+  order: LO
+- name: LCF_vvh_bb_250GeV
+  order: LO
+- name: LCF_zh_250GeV
+  order: NLO_EW
+- name: LCF_bb_250GeV
+  order: LO
+- name: LCF_ww_250GeV
+  order: LO
+- name: LCF_zh_aa_250GeV
+  order: NLO_EW
+- name: LCF_bb_Afb_250GeV
+  order: LO
+- name: LCF_Wwidth_250GeV
+  order: LO
+- name: LCF_zh_aZ_250GeV
+  order: NLO_EW
+- name: LCF_Brw_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_bb_250GeV
+  order: NLO_EW
+- name: LCF_cc_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_cc_250GeV
+  order: NLO_EW
+- name: LCF_cc_Afb_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_gg_250GeV
+  order: NLO_EW
+- name: LCF_ee_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_zh_mumu_250GeV
+  order: NLO_EW
+- name: LCF_ee_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_tautau_250GeV
+  order: NLO_EW
+- name: LCF_mumu_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_ww_250GeV
+  order: NLO_EW
+- name: LCF_mumu_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_zz_250GeV
+  order: NLO_EW
+- name: LCF_tautau_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_tautau_Afb_250GeV
+  order: LO
+- name: LCF_Zdata_250GeV
+  order: LO
+- name: LCF_Brw_350GeV
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_350GeV
+  order: LO
+- name: LCF_vvh_bb_350GeV
+  order: LO
+- name: LCF_vvh_cc_350GeV
+  order: LO
+- name: LCF_vvh_gg_350GeV
+  order: LO
+- name: LCF_vvh_mumu_350GeV
+  order: LO
+- name: LCF_vvh_tautau_350GeV
+  order: LO
+- name: LCF_vvh_ww_350GeV
+  order: LO
+- name: LCF_vvh_zz_350GeV
+  order: LO
+- name: LCF_ww_350GeV
+  order: LO
+- name: LCF_zh_350GeV
+  order: NLO_EW
+- name: LCF_zh_aa_350GeV
+  order: NLO_EW
+- name: LCF_zh_bb_350GeV
+  order: NLO_EW
+- name: LCF_zh_cc_350GeV
+  order: NLO_EW
+- name: LCF_zh_gg_350GeV
+  order: NLO_EW
+- name: LCF_zh_mumu_350GeV
+  order: NLO_EW
+- name: LCF_zh_tautau_350GeV
+  order: NLO_EW
+- name: LCF_zh_ww_350GeV
+  order: NLO_EW
+- name: LCF_zh_zz_350GeV
+  order: NLO_EW
+- name: LCF_bb_500GeV_4ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_4ab
+  order: LO
+- name: LCF_Brw_500GeV_4ab
+  order: LO
+- name: LCF_cc_500GeV_4ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_4ab
+  order: LO
+- name: LCF_ee_500GeV_4ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_4ab
+  order: LO
+- name: LCF_mumu_500GeV_4ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tautau_500GeV_4ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tth_500GeV_4ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_4ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_4ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_4ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_4ab
+  order: LO
+- name: LCF_vvhh_500GeV_4ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_4ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_4ab
+  order: LO
+- name: LCF_ww_500GeV_4ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_4ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_zh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_zh_ww_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_4ab
+  order: NLO_EW
+- name: LCF_bb_500GeV_8ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_8ab
+  order: LO
+- name: LCF_Brw_500GeV_8ab
+  order: LO
+- name: LCF_cc_500GeV_8ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_8ab
+  order: LO
+- name: LCF_ee_500GeV_8ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_8ab
+  order: LO
+- name: LCF_mumu_500GeV_8ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tautau_500GeV_8ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tth_500GeV_8ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_8ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_8ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_8ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_8ab
+  order: LO
+- name: LCF_vvhh_500GeV_8ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_8ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_8ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_8ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_8ab
+  order: LO
+- name: LCF_ww_500GeV_8ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_8ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_tautau_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_ww_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_8ab
+  order: NLO_EW
+- name: LCF_bb_1000GeV
+  order: LO
+- name: LCF_bb_Afb_1000GeV
+  order: LO
+- name: LCF_cc_1000GeV
+  order: LO
+- name: LCF_cc_Afb_1000GeV
+  order: LO
+- name: LCF_ee_1000GeV
+  order: LO
+- name: LCF_ee_Afb_1000GeV
+  order: LO
+- name: LCF_mumu_1000GeV
+  order: LO
+- name: LCF_mumu_Afb_1000GeV
+  order: LO
+- name: LCF_tautau_1000GeV
+  order: LO
+- name: LCF_tautau_Afb_1000GeV
+  order: LO
+- name: LCF_tth_1000GeV
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_vvh_aa_1000GeV
+  order: LO
+- name: LCF_vvh_bb_1000GeV
+  order: LO
+- name: LCF_vvh_cc_1000GeV
+  order: LO
+- name: LCF_vvh_gg_1000GeV
+  order: LO
+- name: LCF_vvhh_1000GeV
+  order: LO
+- name: LCF_vvh_mumu_1000GeV
+  order: LO
+- name: LCF_vvh_tautau_1000GeV
+  order: LO
+- name: LCF_vvh_ww_1000GeV
+  order: LO
+- name: LCF_vvh_zz_1000GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_pos20
   order: LO
 - name: LEP1_EWPOs_2006
   order: LO
@@ -1200,6 +1550,64 @@ datasets:
 - name: LEP_eeWW_198GeV
   order: LO
 - name: LEP_eeWW_206GeV
+  order: LO
+- name: LEP3_240_H_HADR
+  order: NLO_EW_only_for_ZH
+- name: LEP3_240_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_240_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Brw
+  order: LO
+- name: LEP3_Rb_240GeV
+  order: LO
+- name: LEP3_Rc_240GeV
+  order: LO
+- name: LEP3_Rmu_240GeV
+  order: LO
+- name: LEP3_Rtau_240GeV
+  order: LO
+- name: LEP3_bb_Afb_240GeV
+  order: LO
+- name: LEP3_cc_Afb_240GeV
+  order: LO
+- name: LEP3_ee_Afb_240GeV
+  order: LO
+- name: LEP3_ee_240GeV
+  order: LO
+- name: LEP3_mumu_Afb_240GeV
+  order: LO
+- name: LEP3_sigmaHad_240GeV
+  order: LO
+- name: LEP3_tautau_Afb_240GeV
+  order: LO
+- name: LEP3_ww_240GeV
+  order: LO
+- name: LEP3_zh_240GeV
+  order: NLO_EW
+- name: LEP3_zh_WW_240GeV
+  order: NLO_EW
+- name: LEP3_zh_ZZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aa_240GeV
+  order: NLO_EW
+- name: LEP3_zh_mumu_240GeV
+  order: NLO_EW
+- name: LEP3_zh_tautau_240GeV
+  order: NLO_EW
+- name: LEP3_ww_161GeV
+  order: LO
+- name: LEP3_161_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_161_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Wwidth
+  order: LO
+- name: LEP3_Zdata
+  order: LO
+- name: LEP3_alphaEW
   order: LO
 external_chi2:
   OptimalWW161:

--- a/sample_cards/1LoopMatching_collection/Mass_scans/SMEFiT_runcard_MassScan_1LoopMatching_Mod_Varphi_UVcoup_1_1Loop.yaml
+++ b/sample_cards/1LoopMatching_collection/Mass_scans/SMEFiT_runcard_MassScan_1LoopMatching_Mod_Varphi_UVcoup_1_1Loop.yaml
@@ -292,7 +292,7 @@ coefficients:
   OtG:
     constrain:
     - m:
-      - 0.0019121280895770068
+      - 0.0015709238991520643
       - -2
     max: 100
     min: -100
@@ -715,6 +715,8 @@ datasets:
   order: NLO_QCD
 - name: ATLAS_tttt_13TeV_slep_inc
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj
+  order: LO
 - name: ATLAS_SSinc_RunII_proj
   order: NLO_QCD
 - name: ATLAS_STXS_runII_13TeV_uncor_proj
@@ -771,8 +773,6 @@ datasets:
   order: NLO_QCD
 - name: CMS_tW_13TeV_slep_inc_proj
   order: NLO_QCD
-- name: CMS_tZ_13TeV_2016_inc_proj
-  order: NLO_QCD
 - name: CMS_tZ_13TeV_pTt_uncor_proj
   order: NLO_QCD
 - name: CMS_t_tch_13TeV_2019_diff_Yt_proj
@@ -811,6 +811,12 @@ datasets:
   order: NLO_QCD
 - name: HLLHC_tt_13TeV_asy
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj_proj
+  order: LO
+- name: HLLHC_H_14TeV_Snowmass
+  order: LO
+- name: HLLHC_H_14TeV_2025
+  order: LO
 - name: CEPC_161_ww_leptonic_optim_obs
   order: LO
 - name: CEPC_161_ww_semilep_optim_obs
@@ -866,6 +872,8 @@ datasets:
 - name: CEPC_zh_gg_240GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_240GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_240GeV
   order: NLO_EW
 - name: CEPC_365_tt_optim_obs
   order: LO
@@ -926,6 +934,8 @@ datasets:
 - name: CEPC_zh_gg_365GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_365GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_365GeV
   order: NLO_EW
 - name: CEPC_Wwidth
   order: LO
@@ -1019,8 +1029,6 @@ datasets:
   order: LO
 - name: FCCee_161_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_161GeV
-  order: LO
 - name: FCCee_ww_161GeV
   order: LO
 - name: FCCee_240_H_HADR
@@ -1029,7 +1037,7 @@ datasets:
   order: LO
 - name: FCCee_240_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_240GeV
+- name: FCCee_Brw
   order: LO
 - name: FCCee_Rb_240GeV
   order: LO
@@ -1045,15 +1053,13 @@ datasets:
   order: LO
 - name: FCCee_ee_Afb_240GeV
   order: LO
+- name: FCCee_ee_240GeV
+  order: LO
 - name: FCCee_mumu_Afb_240GeV
   order: LO
 - name: FCCee_sigmaHad_240GeV
   order: LO
 - name: FCCee_tautau_Afb_240GeV
-  order: LO
-- name: FCCee_vvh_240GeV
-  order: LO
-- name: FCCee_vvh_bb_240GeV
   order: LO
 - name: FCCee_ww_240GeV
   order: LO
@@ -1067,13 +1073,9 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_aa_240GeV
   order: NLO_EW
-- name: FCCee_zh_bb_240GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_240GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_240GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_240GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_240GeV
   order: NLO_EW
 - name: FCCee_365_H_HADR
   order: NLO_EW_only_for_ZH
@@ -1082,8 +1084,6 @@ datasets:
 - name: FCCee_365_ww_leptonic_optim_obs
   order: LO
 - name: FCCee_365_ww_semilep_optim_obs
-  order: LO
-- name: FCCee_Brw_365GeV
   order: LO
 - name: FCCee_Rb_365GeV
   order: LO
@@ -1097,27 +1097,23 @@ datasets:
   order: LO
 - name: FCCee_cc_Afb_365GeV
   order: LO
+- name: FCCee_mumu_Afb_365GeV
+  order: LO
 - name: FCCee_ee_Afb_365GeV
   order: LO
-- name: FCCee_mumu_Afb_365GeV
+- name: FCCee_ee_365GeV
   order: LO
 - name: FCCee_sigmaHad_365GeV
   order: LO
 - name: FCCee_tautau_Afb_365GeV
   order: LO
-- name: FCCee_vvh_365GeV
-  order: LO
 - name: FCCee_vvh_WW_365GeV
   order: LO
 - name: FCCee_vvh_ZZ_365GeV
   order: LO
+- name: FCCee_vvh_aZ_365GeV
+  order: LO
 - name: FCCee_vvh_aa_365GeV
-  order: LO
-- name: FCCee_vvh_bb_365GeV
-  order: LO
-- name: FCCee_vvh_cc_365GeV
-  order: LO
-- name: FCCee_vvh_gg_365GeV
   order: LO
 - name: FCCee_vvh_tautau_365GeV
   order: LO
@@ -1129,21 +1125,375 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_ZZ_365GeV
   order: NLO_EW
+- name: FCCee_zh_aZ_365GeV
+  order: NLO_EW
 - name: FCCee_zh_aa_365GeV
   order: NLO_EW
-- name: FCCee_zh_bb_365GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_365GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_365GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_365GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_365GeV
   order: NLO_EW
 - name: FCCee_Wwidth
   order: LO
 - name: FCCee_Zdata
   order: LO
 - name: FCCee_alphaEW
+  order: LO
+- name: LCF_Zdata_GigaZ
+  order: LO
+- name: LCF_alphaEW_250GeV
+  order: LO
+- name: LCF_vvh_bb_250GeV
+  order: LO
+- name: LCF_zh_250GeV
+  order: NLO_EW
+- name: LCF_bb_250GeV
+  order: LO
+- name: LCF_ww_250GeV
+  order: LO
+- name: LCF_zh_aa_250GeV
+  order: NLO_EW
+- name: LCF_bb_Afb_250GeV
+  order: LO
+- name: LCF_Wwidth_250GeV
+  order: LO
+- name: LCF_zh_aZ_250GeV
+  order: NLO_EW
+- name: LCF_Brw_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_bb_250GeV
+  order: NLO_EW
+- name: LCF_cc_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_cc_250GeV
+  order: NLO_EW
+- name: LCF_cc_Afb_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_gg_250GeV
+  order: NLO_EW
+- name: LCF_ee_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_zh_mumu_250GeV
+  order: NLO_EW
+- name: LCF_ee_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_tautau_250GeV
+  order: NLO_EW
+- name: LCF_mumu_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_ww_250GeV
+  order: NLO_EW
+- name: LCF_mumu_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_zz_250GeV
+  order: NLO_EW
+- name: LCF_tautau_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_tautau_Afb_250GeV
+  order: LO
+- name: LCF_Zdata_250GeV
+  order: LO
+- name: LCF_Brw_350GeV
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_350GeV
+  order: LO
+- name: LCF_vvh_bb_350GeV
+  order: LO
+- name: LCF_vvh_cc_350GeV
+  order: LO
+- name: LCF_vvh_gg_350GeV
+  order: LO
+- name: LCF_vvh_mumu_350GeV
+  order: LO
+- name: LCF_vvh_tautau_350GeV
+  order: LO
+- name: LCF_vvh_ww_350GeV
+  order: LO
+- name: LCF_vvh_zz_350GeV
+  order: LO
+- name: LCF_ww_350GeV
+  order: LO
+- name: LCF_zh_350GeV
+  order: NLO_EW
+- name: LCF_zh_aa_350GeV
+  order: NLO_EW
+- name: LCF_zh_bb_350GeV
+  order: NLO_EW
+- name: LCF_zh_cc_350GeV
+  order: NLO_EW
+- name: LCF_zh_gg_350GeV
+  order: NLO_EW
+- name: LCF_zh_mumu_350GeV
+  order: NLO_EW
+- name: LCF_zh_tautau_350GeV
+  order: NLO_EW
+- name: LCF_zh_ww_350GeV
+  order: NLO_EW
+- name: LCF_zh_zz_350GeV
+  order: NLO_EW
+- name: LCF_bb_500GeV_4ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_4ab
+  order: LO
+- name: LCF_Brw_500GeV_4ab
+  order: LO
+- name: LCF_cc_500GeV_4ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_4ab
+  order: LO
+- name: LCF_ee_500GeV_4ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_4ab
+  order: LO
+- name: LCF_mumu_500GeV_4ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tautau_500GeV_4ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tth_500GeV_4ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_4ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_4ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_4ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_4ab
+  order: LO
+- name: LCF_vvhh_500GeV_4ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_4ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_4ab
+  order: LO
+- name: LCF_ww_500GeV_4ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_4ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_zh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_zh_ww_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_4ab
+  order: NLO_EW
+- name: LCF_bb_500GeV_8ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_8ab
+  order: LO
+- name: LCF_Brw_500GeV_8ab
+  order: LO
+- name: LCF_cc_500GeV_8ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_8ab
+  order: LO
+- name: LCF_ee_500GeV_8ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_8ab
+  order: LO
+- name: LCF_mumu_500GeV_8ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tautau_500GeV_8ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tth_500GeV_8ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_8ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_8ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_8ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_8ab
+  order: LO
+- name: LCF_vvhh_500GeV_8ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_8ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_8ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_8ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_8ab
+  order: LO
+- name: LCF_ww_500GeV_8ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_8ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_tautau_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_ww_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_8ab
+  order: NLO_EW
+- name: LCF_bb_1000GeV
+  order: LO
+- name: LCF_bb_Afb_1000GeV
+  order: LO
+- name: LCF_cc_1000GeV
+  order: LO
+- name: LCF_cc_Afb_1000GeV
+  order: LO
+- name: LCF_ee_1000GeV
+  order: LO
+- name: LCF_ee_Afb_1000GeV
+  order: LO
+- name: LCF_mumu_1000GeV
+  order: LO
+- name: LCF_mumu_Afb_1000GeV
+  order: LO
+- name: LCF_tautau_1000GeV
+  order: LO
+- name: LCF_tautau_Afb_1000GeV
+  order: LO
+- name: LCF_tth_1000GeV
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_vvh_aa_1000GeV
+  order: LO
+- name: LCF_vvh_bb_1000GeV
+  order: LO
+- name: LCF_vvh_cc_1000GeV
+  order: LO
+- name: LCF_vvh_gg_1000GeV
+  order: LO
+- name: LCF_vvhh_1000GeV
+  order: LO
+- name: LCF_vvh_mumu_1000GeV
+  order: LO
+- name: LCF_vvh_tautau_1000GeV
+  order: LO
+- name: LCF_vvh_ww_1000GeV
+  order: LO
+- name: LCF_vvh_zz_1000GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_pos20
   order: LO
 - name: LEP1_EWPOs_2006
   order: LO
@@ -1160,6 +1510,64 @@ datasets:
 - name: LEP_eeWW_198GeV
   order: LO
 - name: LEP_eeWW_206GeV
+  order: LO
+- name: LEP3_240_H_HADR
+  order: NLO_EW_only_for_ZH
+- name: LEP3_240_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_240_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Brw
+  order: LO
+- name: LEP3_Rb_240GeV
+  order: LO
+- name: LEP3_Rc_240GeV
+  order: LO
+- name: LEP3_Rmu_240GeV
+  order: LO
+- name: LEP3_Rtau_240GeV
+  order: LO
+- name: LEP3_bb_Afb_240GeV
+  order: LO
+- name: LEP3_cc_Afb_240GeV
+  order: LO
+- name: LEP3_ee_Afb_240GeV
+  order: LO
+- name: LEP3_ee_240GeV
+  order: LO
+- name: LEP3_mumu_Afb_240GeV
+  order: LO
+- name: LEP3_sigmaHad_240GeV
+  order: LO
+- name: LEP3_tautau_Afb_240GeV
+  order: LO
+- name: LEP3_ww_240GeV
+  order: LO
+- name: LEP3_zh_240GeV
+  order: NLO_EW
+- name: LEP3_zh_WW_240GeV
+  order: NLO_EW
+- name: LEP3_zh_ZZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aa_240GeV
+  order: NLO_EW
+- name: LEP3_zh_mumu_240GeV
+  order: NLO_EW
+- name: LEP3_zh_tautau_240GeV
+  order: NLO_EW
+- name: LEP3_ww_161GeV
+  order: LO
+- name: LEP3_161_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_161_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Wwidth
+  order: LO
+- name: LEP3_Zdata
+  order: LO
+- name: LEP3_alphaEW
   order: LO
 external_chi2:
   OptimalWW161:

--- a/sample_cards/1LoopMatching_collection/Mass_scans/out_UV_MasScan_dict_Coll_1LoopMatching_Mod_Varphi_Mass_1_1Loop.yaml
+++ b/sample_cards/1LoopMatching_collection/Mass_scans/out_UV_MasScan_dict_Coll_1LoopMatching_Mod_Varphi_Mass_1_1Loop.yaml
@@ -58,7 +58,7 @@ cll1221 : [{m: [-4.794778662810249e-6,-2]}]
 cll1111 : [{m: [-2.61422780651428e-6,-2]}]
 cbp : [{m: [0.00022765148598325797,-2]}]
 ctp : [{m: [-0.9970325672122538,-2]}]
-ctG : [{m: [0.0019121280895770068,-2]}]
+ctG : [{m: [0.0015709238991520643,-2]}]
 ccp : [{m: [0.,0]}]
 ctap : [{m: [0.00006469384887486835,-2]}]
 cmup : [{m: [0.,0]}]
@@ -111,4 +111,4 @@ cQl33 : [{m: [0.00003269799260878696,-2]}]
 # ~~~~~~~~~~~~~~~~~~~~~~
 # Miscellaneous information
 # Matching results address: /home/alejorossia/match2fit//sample_results/MatchingResult_Varphi_oneloop.dat
-# Export date: Tue 30 Sep 2025 08:05:40
+# Export date: Fri 13 Feb 2026 08:48:14

--- a/sample_cards/1LoopMatching_collection/UV_scans/SMEFiT_runcard_1LoopMatching_Mod_T2_Mass_10_1Loop.yaml
+++ b/sample_cards/1LoopMatching_collection/UV_scans/SMEFiT_runcard_1LoopMatching_Mod_T2_Mass_10_1Loop.yaml
@@ -437,7 +437,7 @@ coefficients:
   OtG:
     constrain:
     - lambdaT23:
-      - 2.390160111971258e-6
+      - 1.9636548739400804e-6
       - 2
     max: 100
     min: -100
@@ -895,6 +895,8 @@ datasets:
   order: NLO_QCD
 - name: ATLAS_tttt_13TeV_slep_inc
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj
+  order: LO
 - name: ATLAS_SSinc_RunII_proj
   order: NLO_QCD
 - name: ATLAS_STXS_runII_13TeV_uncor_proj
@@ -951,8 +953,6 @@ datasets:
   order: NLO_QCD
 - name: CMS_tW_13TeV_slep_inc_proj
   order: NLO_QCD
-- name: CMS_tZ_13TeV_2016_inc_proj
-  order: NLO_QCD
 - name: CMS_tZ_13TeV_pTt_uncor_proj
   order: NLO_QCD
 - name: CMS_t_tch_13TeV_2019_diff_Yt_proj
@@ -991,6 +991,12 @@ datasets:
   order: NLO_QCD
 - name: HLLHC_tt_13TeV_asy
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj_proj
+  order: LO
+- name: HLLHC_H_14TeV_Snowmass
+  order: LO
+- name: HLLHC_H_14TeV_2025
+  order: LO
 - name: CEPC_161_ww_leptonic_optim_obs
   order: LO
 - name: CEPC_161_ww_semilep_optim_obs
@@ -1046,6 +1052,8 @@ datasets:
 - name: CEPC_zh_gg_240GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_240GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_240GeV
   order: NLO_EW
 - name: CEPC_365_tt_optim_obs
   order: LO
@@ -1106,6 +1114,8 @@ datasets:
 - name: CEPC_zh_gg_365GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_365GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_365GeV
   order: NLO_EW
 - name: CEPC_Wwidth
   order: LO
@@ -1199,8 +1209,6 @@ datasets:
   order: LO
 - name: FCCee_161_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_161GeV
-  order: LO
 - name: FCCee_ww_161GeV
   order: LO
 - name: FCCee_240_H_HADR
@@ -1209,7 +1217,7 @@ datasets:
   order: LO
 - name: FCCee_240_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_240GeV
+- name: FCCee_Brw
   order: LO
 - name: FCCee_Rb_240GeV
   order: LO
@@ -1225,15 +1233,13 @@ datasets:
   order: LO
 - name: FCCee_ee_Afb_240GeV
   order: LO
+- name: FCCee_ee_240GeV
+  order: LO
 - name: FCCee_mumu_Afb_240GeV
   order: LO
 - name: FCCee_sigmaHad_240GeV
   order: LO
 - name: FCCee_tautau_Afb_240GeV
-  order: LO
-- name: FCCee_vvh_240GeV
-  order: LO
-- name: FCCee_vvh_bb_240GeV
   order: LO
 - name: FCCee_ww_240GeV
   order: LO
@@ -1247,13 +1253,9 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_aa_240GeV
   order: NLO_EW
-- name: FCCee_zh_bb_240GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_240GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_240GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_240GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_240GeV
   order: NLO_EW
 - name: FCCee_365_H_HADR
   order: NLO_EW_only_for_ZH
@@ -1262,8 +1264,6 @@ datasets:
 - name: FCCee_365_ww_leptonic_optim_obs
   order: LO
 - name: FCCee_365_ww_semilep_optim_obs
-  order: LO
-- name: FCCee_Brw_365GeV
   order: LO
 - name: FCCee_Rb_365GeV
   order: LO
@@ -1277,27 +1277,23 @@ datasets:
   order: LO
 - name: FCCee_cc_Afb_365GeV
   order: LO
+- name: FCCee_mumu_Afb_365GeV
+  order: LO
 - name: FCCee_ee_Afb_365GeV
   order: LO
-- name: FCCee_mumu_Afb_365GeV
+- name: FCCee_ee_365GeV
   order: LO
 - name: FCCee_sigmaHad_365GeV
   order: LO
 - name: FCCee_tautau_Afb_365GeV
   order: LO
-- name: FCCee_vvh_365GeV
-  order: LO
 - name: FCCee_vvh_WW_365GeV
   order: LO
 - name: FCCee_vvh_ZZ_365GeV
   order: LO
+- name: FCCee_vvh_aZ_365GeV
+  order: LO
 - name: FCCee_vvh_aa_365GeV
-  order: LO
-- name: FCCee_vvh_bb_365GeV
-  order: LO
-- name: FCCee_vvh_cc_365GeV
-  order: LO
-- name: FCCee_vvh_gg_365GeV
   order: LO
 - name: FCCee_vvh_tautau_365GeV
   order: LO
@@ -1309,21 +1305,375 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_ZZ_365GeV
   order: NLO_EW
+- name: FCCee_zh_aZ_365GeV
+  order: NLO_EW
 - name: FCCee_zh_aa_365GeV
   order: NLO_EW
-- name: FCCee_zh_bb_365GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_365GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_365GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_365GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_365GeV
   order: NLO_EW
 - name: FCCee_Wwidth
   order: LO
 - name: FCCee_Zdata
   order: LO
 - name: FCCee_alphaEW
+  order: LO
+- name: LCF_Zdata_GigaZ
+  order: LO
+- name: LCF_alphaEW_250GeV
+  order: LO
+- name: LCF_vvh_bb_250GeV
+  order: LO
+- name: LCF_zh_250GeV
+  order: NLO_EW
+- name: LCF_bb_250GeV
+  order: LO
+- name: LCF_ww_250GeV
+  order: LO
+- name: LCF_zh_aa_250GeV
+  order: NLO_EW
+- name: LCF_bb_Afb_250GeV
+  order: LO
+- name: LCF_Wwidth_250GeV
+  order: LO
+- name: LCF_zh_aZ_250GeV
+  order: NLO_EW
+- name: LCF_Brw_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_bb_250GeV
+  order: NLO_EW
+- name: LCF_cc_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_cc_250GeV
+  order: NLO_EW
+- name: LCF_cc_Afb_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_gg_250GeV
+  order: NLO_EW
+- name: LCF_ee_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_zh_mumu_250GeV
+  order: NLO_EW
+- name: LCF_ee_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_tautau_250GeV
+  order: NLO_EW
+- name: LCF_mumu_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_ww_250GeV
+  order: NLO_EW
+- name: LCF_mumu_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_zz_250GeV
+  order: NLO_EW
+- name: LCF_tautau_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_tautau_Afb_250GeV
+  order: LO
+- name: LCF_Zdata_250GeV
+  order: LO
+- name: LCF_Brw_350GeV
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_350GeV
+  order: LO
+- name: LCF_vvh_bb_350GeV
+  order: LO
+- name: LCF_vvh_cc_350GeV
+  order: LO
+- name: LCF_vvh_gg_350GeV
+  order: LO
+- name: LCF_vvh_mumu_350GeV
+  order: LO
+- name: LCF_vvh_tautau_350GeV
+  order: LO
+- name: LCF_vvh_ww_350GeV
+  order: LO
+- name: LCF_vvh_zz_350GeV
+  order: LO
+- name: LCF_ww_350GeV
+  order: LO
+- name: LCF_zh_350GeV
+  order: NLO_EW
+- name: LCF_zh_aa_350GeV
+  order: NLO_EW
+- name: LCF_zh_bb_350GeV
+  order: NLO_EW
+- name: LCF_zh_cc_350GeV
+  order: NLO_EW
+- name: LCF_zh_gg_350GeV
+  order: NLO_EW
+- name: LCF_zh_mumu_350GeV
+  order: NLO_EW
+- name: LCF_zh_tautau_350GeV
+  order: NLO_EW
+- name: LCF_zh_ww_350GeV
+  order: NLO_EW
+- name: LCF_zh_zz_350GeV
+  order: NLO_EW
+- name: LCF_bb_500GeV_4ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_4ab
+  order: LO
+- name: LCF_Brw_500GeV_4ab
+  order: LO
+- name: LCF_cc_500GeV_4ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_4ab
+  order: LO
+- name: LCF_ee_500GeV_4ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_4ab
+  order: LO
+- name: LCF_mumu_500GeV_4ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tautau_500GeV_4ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tth_500GeV_4ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_4ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_4ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_4ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_4ab
+  order: LO
+- name: LCF_vvhh_500GeV_4ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_4ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_4ab
+  order: LO
+- name: LCF_ww_500GeV_4ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_4ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_zh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_zh_ww_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_4ab
+  order: NLO_EW
+- name: LCF_bb_500GeV_8ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_8ab
+  order: LO
+- name: LCF_Brw_500GeV_8ab
+  order: LO
+- name: LCF_cc_500GeV_8ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_8ab
+  order: LO
+- name: LCF_ee_500GeV_8ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_8ab
+  order: LO
+- name: LCF_mumu_500GeV_8ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tautau_500GeV_8ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tth_500GeV_8ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_8ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_8ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_8ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_8ab
+  order: LO
+- name: LCF_vvhh_500GeV_8ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_8ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_8ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_8ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_8ab
+  order: LO
+- name: LCF_ww_500GeV_8ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_8ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_tautau_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_ww_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_8ab
+  order: NLO_EW
+- name: LCF_bb_1000GeV
+  order: LO
+- name: LCF_bb_Afb_1000GeV
+  order: LO
+- name: LCF_cc_1000GeV
+  order: LO
+- name: LCF_cc_Afb_1000GeV
+  order: LO
+- name: LCF_ee_1000GeV
+  order: LO
+- name: LCF_ee_Afb_1000GeV
+  order: LO
+- name: LCF_mumu_1000GeV
+  order: LO
+- name: LCF_mumu_Afb_1000GeV
+  order: LO
+- name: LCF_tautau_1000GeV
+  order: LO
+- name: LCF_tautau_Afb_1000GeV
+  order: LO
+- name: LCF_tth_1000GeV
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_vvh_aa_1000GeV
+  order: LO
+- name: LCF_vvh_bb_1000GeV
+  order: LO
+- name: LCF_vvh_cc_1000GeV
+  order: LO
+- name: LCF_vvh_gg_1000GeV
+  order: LO
+- name: LCF_vvhh_1000GeV
+  order: LO
+- name: LCF_vvh_mumu_1000GeV
+  order: LO
+- name: LCF_vvh_tautau_1000GeV
+  order: LO
+- name: LCF_vvh_ww_1000GeV
+  order: LO
+- name: LCF_vvh_zz_1000GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_pos20
   order: LO
 - name: LEP1_EWPOs_2006
   order: LO
@@ -1340,6 +1690,64 @@ datasets:
 - name: LEP_eeWW_198GeV
   order: LO
 - name: LEP_eeWW_206GeV
+  order: LO
+- name: LEP3_240_H_HADR
+  order: NLO_EW_only_for_ZH
+- name: LEP3_240_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_240_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Brw
+  order: LO
+- name: LEP3_Rb_240GeV
+  order: LO
+- name: LEP3_Rc_240GeV
+  order: LO
+- name: LEP3_Rmu_240GeV
+  order: LO
+- name: LEP3_Rtau_240GeV
+  order: LO
+- name: LEP3_bb_Afb_240GeV
+  order: LO
+- name: LEP3_cc_Afb_240GeV
+  order: LO
+- name: LEP3_ee_Afb_240GeV
+  order: LO
+- name: LEP3_ee_240GeV
+  order: LO
+- name: LEP3_mumu_Afb_240GeV
+  order: LO
+- name: LEP3_sigmaHad_240GeV
+  order: LO
+- name: LEP3_tautau_Afb_240GeV
+  order: LO
+- name: LEP3_ww_240GeV
+  order: LO
+- name: LEP3_zh_240GeV
+  order: NLO_EW
+- name: LEP3_zh_WW_240GeV
+  order: NLO_EW
+- name: LEP3_zh_ZZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aa_240GeV
+  order: NLO_EW
+- name: LEP3_zh_mumu_240GeV
+  order: NLO_EW
+- name: LEP3_zh_tautau_240GeV
+  order: NLO_EW
+- name: LEP3_ww_161GeV
+  order: LO
+- name: LEP3_161_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_161_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Wwidth
+  order: LO
+- name: LEP3_Zdata
+  order: LO
+- name: LEP3_alphaEW
   order: LO
 external_chi2:
   OptimalWW161:

--- a/sample_cards/1LoopMatching_collection/UV_scans/SMEFiT_runcard_1LoopMatching_Mod_Varphi_Mass_8_1Loop.yaml
+++ b/sample_cards/1LoopMatching_collection/UV_scans/SMEFiT_runcard_1LoopMatching_Mod_Varphi_Mass_8_1Loop.yaml
@@ -466,7 +466,7 @@ coefficients:
   OtG:
     constrain:
     - lamvarphi:
-      - 0.00002987700139964073
+      - 0.000024545685924251005
       - 0
       yVarphiuf33:
       - 1
@@ -972,6 +972,8 @@ datasets:
   order: NLO_QCD
 - name: ATLAS_tttt_13TeV_slep_inc
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj
+  order: LO
 - name: ATLAS_SSinc_RunII_proj
   order: NLO_QCD
 - name: ATLAS_STXS_runII_13TeV_uncor_proj
@@ -1028,8 +1030,6 @@ datasets:
   order: NLO_QCD
 - name: CMS_tW_13TeV_slep_inc_proj
   order: NLO_QCD
-- name: CMS_tZ_13TeV_2016_inc_proj
-  order: NLO_QCD
 - name: CMS_tZ_13TeV_pTt_uncor_proj
   order: NLO_QCD
 - name: CMS_t_tch_13TeV_2019_diff_Yt_proj
@@ -1068,6 +1068,12 @@ datasets:
   order: NLO_QCD
 - name: HLLHC_tt_13TeV_asy
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj_proj
+  order: LO
+- name: HLLHC_H_14TeV_Snowmass
+  order: LO
+- name: HLLHC_H_14TeV_2025
+  order: LO
 - name: CEPC_161_ww_leptonic_optim_obs
   order: LO
 - name: CEPC_161_ww_semilep_optim_obs
@@ -1123,6 +1129,8 @@ datasets:
 - name: CEPC_zh_gg_240GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_240GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_240GeV
   order: NLO_EW
 - name: CEPC_365_tt_optim_obs
   order: LO
@@ -1183,6 +1191,8 @@ datasets:
 - name: CEPC_zh_gg_365GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_365GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_365GeV
   order: NLO_EW
 - name: CEPC_Wwidth
   order: LO
@@ -1276,8 +1286,6 @@ datasets:
   order: LO
 - name: FCCee_161_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_161GeV
-  order: LO
 - name: FCCee_ww_161GeV
   order: LO
 - name: FCCee_240_H_HADR
@@ -1286,7 +1294,7 @@ datasets:
   order: LO
 - name: FCCee_240_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_240GeV
+- name: FCCee_Brw
   order: LO
 - name: FCCee_Rb_240GeV
   order: LO
@@ -1302,15 +1310,13 @@ datasets:
   order: LO
 - name: FCCee_ee_Afb_240GeV
   order: LO
+- name: FCCee_ee_240GeV
+  order: LO
 - name: FCCee_mumu_Afb_240GeV
   order: LO
 - name: FCCee_sigmaHad_240GeV
   order: LO
 - name: FCCee_tautau_Afb_240GeV
-  order: LO
-- name: FCCee_vvh_240GeV
-  order: LO
-- name: FCCee_vvh_bb_240GeV
   order: LO
 - name: FCCee_ww_240GeV
   order: LO
@@ -1324,13 +1330,9 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_aa_240GeV
   order: NLO_EW
-- name: FCCee_zh_bb_240GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_240GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_240GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_240GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_240GeV
   order: NLO_EW
 - name: FCCee_365_H_HADR
   order: NLO_EW_only_for_ZH
@@ -1339,8 +1341,6 @@ datasets:
 - name: FCCee_365_ww_leptonic_optim_obs
   order: LO
 - name: FCCee_365_ww_semilep_optim_obs
-  order: LO
-- name: FCCee_Brw_365GeV
   order: LO
 - name: FCCee_Rb_365GeV
   order: LO
@@ -1354,27 +1354,23 @@ datasets:
   order: LO
 - name: FCCee_cc_Afb_365GeV
   order: LO
+- name: FCCee_mumu_Afb_365GeV
+  order: LO
 - name: FCCee_ee_Afb_365GeV
   order: LO
-- name: FCCee_mumu_Afb_365GeV
+- name: FCCee_ee_365GeV
   order: LO
 - name: FCCee_sigmaHad_365GeV
   order: LO
 - name: FCCee_tautau_Afb_365GeV
   order: LO
-- name: FCCee_vvh_365GeV
-  order: LO
 - name: FCCee_vvh_WW_365GeV
   order: LO
 - name: FCCee_vvh_ZZ_365GeV
   order: LO
+- name: FCCee_vvh_aZ_365GeV
+  order: LO
 - name: FCCee_vvh_aa_365GeV
-  order: LO
-- name: FCCee_vvh_bb_365GeV
-  order: LO
-- name: FCCee_vvh_cc_365GeV
-  order: LO
-- name: FCCee_vvh_gg_365GeV
   order: LO
 - name: FCCee_vvh_tautau_365GeV
   order: LO
@@ -1386,21 +1382,375 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_ZZ_365GeV
   order: NLO_EW
+- name: FCCee_zh_aZ_365GeV
+  order: NLO_EW
 - name: FCCee_zh_aa_365GeV
   order: NLO_EW
-- name: FCCee_zh_bb_365GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_365GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_365GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_365GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_365GeV
   order: NLO_EW
 - name: FCCee_Wwidth
   order: LO
 - name: FCCee_Zdata
   order: LO
 - name: FCCee_alphaEW
+  order: LO
+- name: LCF_Zdata_GigaZ
+  order: LO
+- name: LCF_alphaEW_250GeV
+  order: LO
+- name: LCF_vvh_bb_250GeV
+  order: LO
+- name: LCF_zh_250GeV
+  order: NLO_EW
+- name: LCF_bb_250GeV
+  order: LO
+- name: LCF_ww_250GeV
+  order: LO
+- name: LCF_zh_aa_250GeV
+  order: NLO_EW
+- name: LCF_bb_Afb_250GeV
+  order: LO
+- name: LCF_Wwidth_250GeV
+  order: LO
+- name: LCF_zh_aZ_250GeV
+  order: NLO_EW
+- name: LCF_Brw_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_bb_250GeV
+  order: NLO_EW
+- name: LCF_cc_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_cc_250GeV
+  order: NLO_EW
+- name: LCF_cc_Afb_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_gg_250GeV
+  order: NLO_EW
+- name: LCF_ee_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_zh_mumu_250GeV
+  order: NLO_EW
+- name: LCF_ee_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_tautau_250GeV
+  order: NLO_EW
+- name: LCF_mumu_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_ww_250GeV
+  order: NLO_EW
+- name: LCF_mumu_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_zz_250GeV
+  order: NLO_EW
+- name: LCF_tautau_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_tautau_Afb_250GeV
+  order: LO
+- name: LCF_Zdata_250GeV
+  order: LO
+- name: LCF_Brw_350GeV
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_350GeV
+  order: LO
+- name: LCF_vvh_bb_350GeV
+  order: LO
+- name: LCF_vvh_cc_350GeV
+  order: LO
+- name: LCF_vvh_gg_350GeV
+  order: LO
+- name: LCF_vvh_mumu_350GeV
+  order: LO
+- name: LCF_vvh_tautau_350GeV
+  order: LO
+- name: LCF_vvh_ww_350GeV
+  order: LO
+- name: LCF_vvh_zz_350GeV
+  order: LO
+- name: LCF_ww_350GeV
+  order: LO
+- name: LCF_zh_350GeV
+  order: NLO_EW
+- name: LCF_zh_aa_350GeV
+  order: NLO_EW
+- name: LCF_zh_bb_350GeV
+  order: NLO_EW
+- name: LCF_zh_cc_350GeV
+  order: NLO_EW
+- name: LCF_zh_gg_350GeV
+  order: NLO_EW
+- name: LCF_zh_mumu_350GeV
+  order: NLO_EW
+- name: LCF_zh_tautau_350GeV
+  order: NLO_EW
+- name: LCF_zh_ww_350GeV
+  order: NLO_EW
+- name: LCF_zh_zz_350GeV
+  order: NLO_EW
+- name: LCF_bb_500GeV_4ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_4ab
+  order: LO
+- name: LCF_Brw_500GeV_4ab
+  order: LO
+- name: LCF_cc_500GeV_4ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_4ab
+  order: LO
+- name: LCF_ee_500GeV_4ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_4ab
+  order: LO
+- name: LCF_mumu_500GeV_4ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tautau_500GeV_4ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tth_500GeV_4ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_4ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_4ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_4ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_4ab
+  order: LO
+- name: LCF_vvhh_500GeV_4ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_4ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_4ab
+  order: LO
+- name: LCF_ww_500GeV_4ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_4ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_zh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_zh_ww_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_4ab
+  order: NLO_EW
+- name: LCF_bb_500GeV_8ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_8ab
+  order: LO
+- name: LCF_Brw_500GeV_8ab
+  order: LO
+- name: LCF_cc_500GeV_8ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_8ab
+  order: LO
+- name: LCF_ee_500GeV_8ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_8ab
+  order: LO
+- name: LCF_mumu_500GeV_8ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tautau_500GeV_8ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tth_500GeV_8ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_8ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_8ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_8ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_8ab
+  order: LO
+- name: LCF_vvhh_500GeV_8ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_8ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_8ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_8ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_8ab
+  order: LO
+- name: LCF_ww_500GeV_8ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_8ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_tautau_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_ww_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_8ab
+  order: NLO_EW
+- name: LCF_bb_1000GeV
+  order: LO
+- name: LCF_bb_Afb_1000GeV
+  order: LO
+- name: LCF_cc_1000GeV
+  order: LO
+- name: LCF_cc_Afb_1000GeV
+  order: LO
+- name: LCF_ee_1000GeV
+  order: LO
+- name: LCF_ee_Afb_1000GeV
+  order: LO
+- name: LCF_mumu_1000GeV
+  order: LO
+- name: LCF_mumu_Afb_1000GeV
+  order: LO
+- name: LCF_tautau_1000GeV
+  order: LO
+- name: LCF_tautau_Afb_1000GeV
+  order: LO
+- name: LCF_tth_1000GeV
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_vvh_aa_1000GeV
+  order: LO
+- name: LCF_vvh_bb_1000GeV
+  order: LO
+- name: LCF_vvh_cc_1000GeV
+  order: LO
+- name: LCF_vvh_gg_1000GeV
+  order: LO
+- name: LCF_vvhh_1000GeV
+  order: LO
+- name: LCF_vvh_mumu_1000GeV
+  order: LO
+- name: LCF_vvh_tautau_1000GeV
+  order: LO
+- name: LCF_vvh_ww_1000GeV
+  order: LO
+- name: LCF_vvh_zz_1000GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_pos20
   order: LO
 - name: LEP1_EWPOs_2006
   order: LO
@@ -1417,6 +1767,64 @@ datasets:
 - name: LEP_eeWW_198GeV
   order: LO
 - name: LEP_eeWW_206GeV
+  order: LO
+- name: LEP3_240_H_HADR
+  order: NLO_EW_only_for_ZH
+- name: LEP3_240_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_240_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Brw
+  order: LO
+- name: LEP3_Rb_240GeV
+  order: LO
+- name: LEP3_Rc_240GeV
+  order: LO
+- name: LEP3_Rmu_240GeV
+  order: LO
+- name: LEP3_Rtau_240GeV
+  order: LO
+- name: LEP3_bb_Afb_240GeV
+  order: LO
+- name: LEP3_cc_Afb_240GeV
+  order: LO
+- name: LEP3_ee_Afb_240GeV
+  order: LO
+- name: LEP3_ee_240GeV
+  order: LO
+- name: LEP3_mumu_Afb_240GeV
+  order: LO
+- name: LEP3_sigmaHad_240GeV
+  order: LO
+- name: LEP3_tautau_Afb_240GeV
+  order: LO
+- name: LEP3_ww_240GeV
+  order: LO
+- name: LEP3_zh_240GeV
+  order: NLO_EW
+- name: LEP3_zh_WW_240GeV
+  order: NLO_EW
+- name: LEP3_zh_ZZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aa_240GeV
+  order: NLO_EW
+- name: LEP3_zh_mumu_240GeV
+  order: NLO_EW
+- name: LEP3_zh_tautau_240GeV
+  order: NLO_EW
+- name: LEP3_ww_161GeV
+  order: LO
+- name: LEP3_161_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_161_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Wwidth
+  order: LO
+- name: LEP3_Zdata
+  order: LO
+- name: LEP3_alphaEW
   order: LO
 external_chi2:
   OptimalWW161:

--- a/sample_cards/1LoopMatching_collection/UV_scans/SMEFiT_runcard_OneLoop_Mod_T1_Mass_10_1Loop.yaml
+++ b/sample_cards/1LoopMatching_collection/UV_scans/SMEFiT_runcard_OneLoop_Mod_T1_Mass_10_1Loop.yaml
@@ -437,7 +437,7 @@ coefficients:
   OtG:
     constrain:
     - lambdaT13:
-      - 0.000016731120783798808
+      - 0.000013745584117580564
       - 2
     max: 100
     min: -100
@@ -895,6 +895,8 @@ datasets:
   order: NLO_QCD
 - name: ATLAS_tttt_13TeV_slep_inc
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj
+  order: LO
 - name: ATLAS_SSinc_RunII_proj
   order: NLO_QCD
 - name: ATLAS_STXS_runII_13TeV_uncor_proj
@@ -951,8 +953,6 @@ datasets:
   order: NLO_QCD
 - name: CMS_tW_13TeV_slep_inc_proj
   order: NLO_QCD
-- name: CMS_tZ_13TeV_2016_inc_proj
-  order: NLO_QCD
 - name: CMS_tZ_13TeV_pTt_uncor_proj
   order: NLO_QCD
 - name: CMS_t_tch_13TeV_2019_diff_Yt_proj
@@ -991,6 +991,12 @@ datasets:
   order: NLO_QCD
 - name: HLLHC_tt_13TeV_asy
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj_proj
+  order: LO
+- name: HLLHC_H_14TeV_Snowmass
+  order: LO
+- name: HLLHC_H_14TeV_2025
+  order: LO
 - name: CEPC_161_ww_leptonic_optim_obs
   order: LO
 - name: CEPC_161_ww_semilep_optim_obs
@@ -1046,6 +1052,8 @@ datasets:
 - name: CEPC_zh_gg_240GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_240GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_240GeV
   order: NLO_EW
 - name: CEPC_365_tt_optim_obs
   order: LO
@@ -1106,6 +1114,8 @@ datasets:
 - name: CEPC_zh_gg_365GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_365GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_365GeV
   order: NLO_EW
 - name: CEPC_Wwidth
   order: LO
@@ -1199,8 +1209,6 @@ datasets:
   order: LO
 - name: FCCee_161_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_161GeV
-  order: LO
 - name: FCCee_ww_161GeV
   order: LO
 - name: FCCee_240_H_HADR
@@ -1209,7 +1217,7 @@ datasets:
   order: LO
 - name: FCCee_240_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_240GeV
+- name: FCCee_Brw
   order: LO
 - name: FCCee_Rb_240GeV
   order: LO
@@ -1225,15 +1233,13 @@ datasets:
   order: LO
 - name: FCCee_ee_Afb_240GeV
   order: LO
+- name: FCCee_ee_240GeV
+  order: LO
 - name: FCCee_mumu_Afb_240GeV
   order: LO
 - name: FCCee_sigmaHad_240GeV
   order: LO
 - name: FCCee_tautau_Afb_240GeV
-  order: LO
-- name: FCCee_vvh_240GeV
-  order: LO
-- name: FCCee_vvh_bb_240GeV
   order: LO
 - name: FCCee_ww_240GeV
   order: LO
@@ -1247,13 +1253,9 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_aa_240GeV
   order: NLO_EW
-- name: FCCee_zh_bb_240GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_240GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_240GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_240GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_240GeV
   order: NLO_EW
 - name: FCCee_365_H_HADR
   order: NLO_EW_only_for_ZH
@@ -1262,8 +1264,6 @@ datasets:
 - name: FCCee_365_ww_leptonic_optim_obs
   order: LO
 - name: FCCee_365_ww_semilep_optim_obs
-  order: LO
-- name: FCCee_Brw_365GeV
   order: LO
 - name: FCCee_Rb_365GeV
   order: LO
@@ -1277,27 +1277,23 @@ datasets:
   order: LO
 - name: FCCee_cc_Afb_365GeV
   order: LO
+- name: FCCee_mumu_Afb_365GeV
+  order: LO
 - name: FCCee_ee_Afb_365GeV
   order: LO
-- name: FCCee_mumu_Afb_365GeV
+- name: FCCee_ee_365GeV
   order: LO
 - name: FCCee_sigmaHad_365GeV
   order: LO
 - name: FCCee_tautau_Afb_365GeV
   order: LO
-- name: FCCee_vvh_365GeV
-  order: LO
 - name: FCCee_vvh_WW_365GeV
   order: LO
 - name: FCCee_vvh_ZZ_365GeV
   order: LO
+- name: FCCee_vvh_aZ_365GeV
+  order: LO
 - name: FCCee_vvh_aa_365GeV
-  order: LO
-- name: FCCee_vvh_bb_365GeV
-  order: LO
-- name: FCCee_vvh_cc_365GeV
-  order: LO
-- name: FCCee_vvh_gg_365GeV
   order: LO
 - name: FCCee_vvh_tautau_365GeV
   order: LO
@@ -1309,21 +1305,375 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_ZZ_365GeV
   order: NLO_EW
+- name: FCCee_zh_aZ_365GeV
+  order: NLO_EW
 - name: FCCee_zh_aa_365GeV
   order: NLO_EW
-- name: FCCee_zh_bb_365GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_365GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_365GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_365GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_365GeV
   order: NLO_EW
 - name: FCCee_Wwidth
   order: LO
 - name: FCCee_Zdata
   order: LO
 - name: FCCee_alphaEW
+  order: LO
+- name: LCF_Zdata_GigaZ
+  order: LO
+- name: LCF_alphaEW_250GeV
+  order: LO
+- name: LCF_vvh_bb_250GeV
+  order: LO
+- name: LCF_zh_250GeV
+  order: NLO_EW
+- name: LCF_bb_250GeV
+  order: LO
+- name: LCF_ww_250GeV
+  order: LO
+- name: LCF_zh_aa_250GeV
+  order: NLO_EW
+- name: LCF_bb_Afb_250GeV
+  order: LO
+- name: LCF_Wwidth_250GeV
+  order: LO
+- name: LCF_zh_aZ_250GeV
+  order: NLO_EW
+- name: LCF_Brw_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_bb_250GeV
+  order: NLO_EW
+- name: LCF_cc_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_cc_250GeV
+  order: NLO_EW
+- name: LCF_cc_Afb_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_gg_250GeV
+  order: NLO_EW
+- name: LCF_ee_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_zh_mumu_250GeV
+  order: NLO_EW
+- name: LCF_ee_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_tautau_250GeV
+  order: NLO_EW
+- name: LCF_mumu_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_ww_250GeV
+  order: NLO_EW
+- name: LCF_mumu_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_zz_250GeV
+  order: NLO_EW
+- name: LCF_tautau_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_tautau_Afb_250GeV
+  order: LO
+- name: LCF_Zdata_250GeV
+  order: LO
+- name: LCF_Brw_350GeV
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_350GeV
+  order: LO
+- name: LCF_vvh_bb_350GeV
+  order: LO
+- name: LCF_vvh_cc_350GeV
+  order: LO
+- name: LCF_vvh_gg_350GeV
+  order: LO
+- name: LCF_vvh_mumu_350GeV
+  order: LO
+- name: LCF_vvh_tautau_350GeV
+  order: LO
+- name: LCF_vvh_ww_350GeV
+  order: LO
+- name: LCF_vvh_zz_350GeV
+  order: LO
+- name: LCF_ww_350GeV
+  order: LO
+- name: LCF_zh_350GeV
+  order: NLO_EW
+- name: LCF_zh_aa_350GeV
+  order: NLO_EW
+- name: LCF_zh_bb_350GeV
+  order: NLO_EW
+- name: LCF_zh_cc_350GeV
+  order: NLO_EW
+- name: LCF_zh_gg_350GeV
+  order: NLO_EW
+- name: LCF_zh_mumu_350GeV
+  order: NLO_EW
+- name: LCF_zh_tautau_350GeV
+  order: NLO_EW
+- name: LCF_zh_ww_350GeV
+  order: NLO_EW
+- name: LCF_zh_zz_350GeV
+  order: NLO_EW
+- name: LCF_bb_500GeV_4ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_4ab
+  order: LO
+- name: LCF_Brw_500GeV_4ab
+  order: LO
+- name: LCF_cc_500GeV_4ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_4ab
+  order: LO
+- name: LCF_ee_500GeV_4ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_4ab
+  order: LO
+- name: LCF_mumu_500GeV_4ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tautau_500GeV_4ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tth_500GeV_4ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_4ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_4ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_4ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_4ab
+  order: LO
+- name: LCF_vvhh_500GeV_4ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_4ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_4ab
+  order: LO
+- name: LCF_ww_500GeV_4ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_4ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_zh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_zh_ww_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_4ab
+  order: NLO_EW
+- name: LCF_bb_500GeV_8ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_8ab
+  order: LO
+- name: LCF_Brw_500GeV_8ab
+  order: LO
+- name: LCF_cc_500GeV_8ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_8ab
+  order: LO
+- name: LCF_ee_500GeV_8ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_8ab
+  order: LO
+- name: LCF_mumu_500GeV_8ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tautau_500GeV_8ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tth_500GeV_8ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_8ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_8ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_8ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_8ab
+  order: LO
+- name: LCF_vvhh_500GeV_8ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_8ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_8ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_8ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_8ab
+  order: LO
+- name: LCF_ww_500GeV_8ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_8ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_tautau_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_ww_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_8ab
+  order: NLO_EW
+- name: LCF_bb_1000GeV
+  order: LO
+- name: LCF_bb_Afb_1000GeV
+  order: LO
+- name: LCF_cc_1000GeV
+  order: LO
+- name: LCF_cc_Afb_1000GeV
+  order: LO
+- name: LCF_ee_1000GeV
+  order: LO
+- name: LCF_ee_Afb_1000GeV
+  order: LO
+- name: LCF_mumu_1000GeV
+  order: LO
+- name: LCF_mumu_Afb_1000GeV
+  order: LO
+- name: LCF_tautau_1000GeV
+  order: LO
+- name: LCF_tautau_Afb_1000GeV
+  order: LO
+- name: LCF_tth_1000GeV
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_vvh_aa_1000GeV
+  order: LO
+- name: LCF_vvh_bb_1000GeV
+  order: LO
+- name: LCF_vvh_cc_1000GeV
+  order: LO
+- name: LCF_vvh_gg_1000GeV
+  order: LO
+- name: LCF_vvhh_1000GeV
+  order: LO
+- name: LCF_vvh_mumu_1000GeV
+  order: LO
+- name: LCF_vvh_tautau_1000GeV
+  order: LO
+- name: LCF_vvh_ww_1000GeV
+  order: LO
+- name: LCF_vvh_zz_1000GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_pos20
   order: LO
 - name: LEP1_EWPOs_2006
   order: LO
@@ -1340,6 +1690,64 @@ datasets:
 - name: LEP_eeWW_198GeV
   order: LO
 - name: LEP_eeWW_206GeV
+  order: LO
+- name: LEP3_240_H_HADR
+  order: NLO_EW_only_for_ZH
+- name: LEP3_240_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_240_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Brw
+  order: LO
+- name: LEP3_Rb_240GeV
+  order: LO
+- name: LEP3_Rc_240GeV
+  order: LO
+- name: LEP3_Rmu_240GeV
+  order: LO
+- name: LEP3_Rtau_240GeV
+  order: LO
+- name: LEP3_bb_Afb_240GeV
+  order: LO
+- name: LEP3_cc_Afb_240GeV
+  order: LO
+- name: LEP3_ee_Afb_240GeV
+  order: LO
+- name: LEP3_ee_240GeV
+  order: LO
+- name: LEP3_mumu_Afb_240GeV
+  order: LO
+- name: LEP3_sigmaHad_240GeV
+  order: LO
+- name: LEP3_tautau_Afb_240GeV
+  order: LO
+- name: LEP3_ww_240GeV
+  order: LO
+- name: LEP3_zh_240GeV
+  order: NLO_EW
+- name: LEP3_zh_WW_240GeV
+  order: NLO_EW
+- name: LEP3_zh_ZZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aa_240GeV
+  order: NLO_EW
+- name: LEP3_zh_mumu_240GeV
+  order: NLO_EW
+- name: LEP3_zh_tautau_240GeV
+  order: NLO_EW
+- name: LEP3_ww_161GeV
+  order: LO
+- name: LEP3_161_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_161_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Wwidth
+  order: LO
+- name: LEP3_Zdata
+  order: LO
+- name: LEP3_alphaEW
   order: LO
 external_chi2:
   OptimalWW161:

--- a/sample_cards/Granada_collection/Mass_scans/SMEFiT_runcard_MassScan_Granada_Mod_Varphi_UVcoup_1_1Loop.yaml
+++ b/sample_cards/Granada_collection/Mass_scans/SMEFiT_runcard_MassScan_Granada_Mod_Varphi_UVcoup_1_1Loop.yaml
@@ -292,7 +292,7 @@ coefficients:
   OtG:
     constrain:
     - m:
-      - 0.0019121280895770068
+      - 0.0015709238991520643
       - -2
     max: 100
     min: -100
@@ -715,6 +715,8 @@ datasets:
   order: NLO_QCD
 - name: ATLAS_tttt_13TeV_slep_inc
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj
+  order: LO
 - name: ATLAS_SSinc_RunII_proj
   order: NLO_QCD
 - name: ATLAS_STXS_runII_13TeV_uncor_proj
@@ -771,8 +773,6 @@ datasets:
   order: NLO_QCD
 - name: CMS_tW_13TeV_slep_inc_proj
   order: NLO_QCD
-- name: CMS_tZ_13TeV_2016_inc_proj
-  order: NLO_QCD
 - name: CMS_tZ_13TeV_pTt_uncor_proj
   order: NLO_QCD
 - name: CMS_t_tch_13TeV_2019_diff_Yt_proj
@@ -811,6 +811,12 @@ datasets:
   order: NLO_QCD
 - name: HLLHC_tt_13TeV_asy
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj_proj
+  order: LO
+- name: HLLHC_H_14TeV_Snowmass
+  order: LO
+- name: HLLHC_H_14TeV_2025
+  order: LO
 - name: CEPC_161_ww_leptonic_optim_obs
   order: LO
 - name: CEPC_161_ww_semilep_optim_obs
@@ -866,6 +872,8 @@ datasets:
 - name: CEPC_zh_gg_240GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_240GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_240GeV
   order: NLO_EW
 - name: CEPC_365_tt_optim_obs
   order: LO
@@ -926,6 +934,8 @@ datasets:
 - name: CEPC_zh_gg_365GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_365GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_365GeV
   order: NLO_EW
 - name: CEPC_Wwidth
   order: LO
@@ -1019,8 +1029,6 @@ datasets:
   order: LO
 - name: FCCee_161_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_161GeV
-  order: LO
 - name: FCCee_ww_161GeV
   order: LO
 - name: FCCee_240_H_HADR
@@ -1029,7 +1037,7 @@ datasets:
   order: LO
 - name: FCCee_240_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_240GeV
+- name: FCCee_Brw
   order: LO
 - name: FCCee_Rb_240GeV
   order: LO
@@ -1045,15 +1053,13 @@ datasets:
   order: LO
 - name: FCCee_ee_Afb_240GeV
   order: LO
+- name: FCCee_ee_240GeV
+  order: LO
 - name: FCCee_mumu_Afb_240GeV
   order: LO
 - name: FCCee_sigmaHad_240GeV
   order: LO
 - name: FCCee_tautau_Afb_240GeV
-  order: LO
-- name: FCCee_vvh_240GeV
-  order: LO
-- name: FCCee_vvh_bb_240GeV
   order: LO
 - name: FCCee_ww_240GeV
   order: LO
@@ -1067,13 +1073,9 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_aa_240GeV
   order: NLO_EW
-- name: FCCee_zh_bb_240GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_240GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_240GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_240GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_240GeV
   order: NLO_EW
 - name: FCCee_365_H_HADR
   order: NLO_EW_only_for_ZH
@@ -1082,8 +1084,6 @@ datasets:
 - name: FCCee_365_ww_leptonic_optim_obs
   order: LO
 - name: FCCee_365_ww_semilep_optim_obs
-  order: LO
-- name: FCCee_Brw_365GeV
   order: LO
 - name: FCCee_Rb_365GeV
   order: LO
@@ -1097,27 +1097,23 @@ datasets:
   order: LO
 - name: FCCee_cc_Afb_365GeV
   order: LO
+- name: FCCee_mumu_Afb_365GeV
+  order: LO
 - name: FCCee_ee_Afb_365GeV
   order: LO
-- name: FCCee_mumu_Afb_365GeV
+- name: FCCee_ee_365GeV
   order: LO
 - name: FCCee_sigmaHad_365GeV
   order: LO
 - name: FCCee_tautau_Afb_365GeV
   order: LO
-- name: FCCee_vvh_365GeV
-  order: LO
 - name: FCCee_vvh_WW_365GeV
   order: LO
 - name: FCCee_vvh_ZZ_365GeV
   order: LO
+- name: FCCee_vvh_aZ_365GeV
+  order: LO
 - name: FCCee_vvh_aa_365GeV
-  order: LO
-- name: FCCee_vvh_bb_365GeV
-  order: LO
-- name: FCCee_vvh_cc_365GeV
-  order: LO
-- name: FCCee_vvh_gg_365GeV
   order: LO
 - name: FCCee_vvh_tautau_365GeV
   order: LO
@@ -1129,21 +1125,375 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_ZZ_365GeV
   order: NLO_EW
+- name: FCCee_zh_aZ_365GeV
+  order: NLO_EW
 - name: FCCee_zh_aa_365GeV
   order: NLO_EW
-- name: FCCee_zh_bb_365GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_365GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_365GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_365GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_365GeV
   order: NLO_EW
 - name: FCCee_Wwidth
   order: LO
 - name: FCCee_Zdata
   order: LO
 - name: FCCee_alphaEW
+  order: LO
+- name: LCF_Zdata_GigaZ
+  order: LO
+- name: LCF_alphaEW_250GeV
+  order: LO
+- name: LCF_vvh_bb_250GeV
+  order: LO
+- name: LCF_zh_250GeV
+  order: NLO_EW
+- name: LCF_bb_250GeV
+  order: LO
+- name: LCF_ww_250GeV
+  order: LO
+- name: LCF_zh_aa_250GeV
+  order: NLO_EW
+- name: LCF_bb_Afb_250GeV
+  order: LO
+- name: LCF_Wwidth_250GeV
+  order: LO
+- name: LCF_zh_aZ_250GeV
+  order: NLO_EW
+- name: LCF_Brw_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_bb_250GeV
+  order: NLO_EW
+- name: LCF_cc_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_cc_250GeV
+  order: NLO_EW
+- name: LCF_cc_Afb_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_gg_250GeV
+  order: NLO_EW
+- name: LCF_ee_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_zh_mumu_250GeV
+  order: NLO_EW
+- name: LCF_ee_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_tautau_250GeV
+  order: NLO_EW
+- name: LCF_mumu_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_ww_250GeV
+  order: NLO_EW
+- name: LCF_mumu_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_zz_250GeV
+  order: NLO_EW
+- name: LCF_tautau_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_tautau_Afb_250GeV
+  order: LO
+- name: LCF_Zdata_250GeV
+  order: LO
+- name: LCF_Brw_350GeV
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_350GeV
+  order: LO
+- name: LCF_vvh_bb_350GeV
+  order: LO
+- name: LCF_vvh_cc_350GeV
+  order: LO
+- name: LCF_vvh_gg_350GeV
+  order: LO
+- name: LCF_vvh_mumu_350GeV
+  order: LO
+- name: LCF_vvh_tautau_350GeV
+  order: LO
+- name: LCF_vvh_ww_350GeV
+  order: LO
+- name: LCF_vvh_zz_350GeV
+  order: LO
+- name: LCF_ww_350GeV
+  order: LO
+- name: LCF_zh_350GeV
+  order: NLO_EW
+- name: LCF_zh_aa_350GeV
+  order: NLO_EW
+- name: LCF_zh_bb_350GeV
+  order: NLO_EW
+- name: LCF_zh_cc_350GeV
+  order: NLO_EW
+- name: LCF_zh_gg_350GeV
+  order: NLO_EW
+- name: LCF_zh_mumu_350GeV
+  order: NLO_EW
+- name: LCF_zh_tautau_350GeV
+  order: NLO_EW
+- name: LCF_zh_ww_350GeV
+  order: NLO_EW
+- name: LCF_zh_zz_350GeV
+  order: NLO_EW
+- name: LCF_bb_500GeV_4ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_4ab
+  order: LO
+- name: LCF_Brw_500GeV_4ab
+  order: LO
+- name: LCF_cc_500GeV_4ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_4ab
+  order: LO
+- name: LCF_ee_500GeV_4ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_4ab
+  order: LO
+- name: LCF_mumu_500GeV_4ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tautau_500GeV_4ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tth_500GeV_4ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_4ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_4ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_4ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_4ab
+  order: LO
+- name: LCF_vvhh_500GeV_4ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_4ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_4ab
+  order: LO
+- name: LCF_ww_500GeV_4ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_4ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_zh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_zh_ww_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_4ab
+  order: NLO_EW
+- name: LCF_bb_500GeV_8ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_8ab
+  order: LO
+- name: LCF_Brw_500GeV_8ab
+  order: LO
+- name: LCF_cc_500GeV_8ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_8ab
+  order: LO
+- name: LCF_ee_500GeV_8ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_8ab
+  order: LO
+- name: LCF_mumu_500GeV_8ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tautau_500GeV_8ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tth_500GeV_8ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_8ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_8ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_8ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_8ab
+  order: LO
+- name: LCF_vvhh_500GeV_8ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_8ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_8ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_8ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_8ab
+  order: LO
+- name: LCF_ww_500GeV_8ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_8ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_tautau_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_ww_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_8ab
+  order: NLO_EW
+- name: LCF_bb_1000GeV
+  order: LO
+- name: LCF_bb_Afb_1000GeV
+  order: LO
+- name: LCF_cc_1000GeV
+  order: LO
+- name: LCF_cc_Afb_1000GeV
+  order: LO
+- name: LCF_ee_1000GeV
+  order: LO
+- name: LCF_ee_Afb_1000GeV
+  order: LO
+- name: LCF_mumu_1000GeV
+  order: LO
+- name: LCF_mumu_Afb_1000GeV
+  order: LO
+- name: LCF_tautau_1000GeV
+  order: LO
+- name: LCF_tautau_Afb_1000GeV
+  order: LO
+- name: LCF_tth_1000GeV
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_vvh_aa_1000GeV
+  order: LO
+- name: LCF_vvh_bb_1000GeV
+  order: LO
+- name: LCF_vvh_cc_1000GeV
+  order: LO
+- name: LCF_vvh_gg_1000GeV
+  order: LO
+- name: LCF_vvhh_1000GeV
+  order: LO
+- name: LCF_vvh_mumu_1000GeV
+  order: LO
+- name: LCF_vvh_tautau_1000GeV
+  order: LO
+- name: LCF_vvh_ww_1000GeV
+  order: LO
+- name: LCF_vvh_zz_1000GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_pos20
   order: LO
 - name: LEP1_EWPOs_2006
   order: LO
@@ -1160,6 +1510,64 @@ datasets:
 - name: LEP_eeWW_198GeV
   order: LO
 - name: LEP_eeWW_206GeV
+  order: LO
+- name: LEP3_240_H_HADR
+  order: NLO_EW_only_for_ZH
+- name: LEP3_240_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_240_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Brw
+  order: LO
+- name: LEP3_Rb_240GeV
+  order: LO
+- name: LEP3_Rc_240GeV
+  order: LO
+- name: LEP3_Rmu_240GeV
+  order: LO
+- name: LEP3_Rtau_240GeV
+  order: LO
+- name: LEP3_bb_Afb_240GeV
+  order: LO
+- name: LEP3_cc_Afb_240GeV
+  order: LO
+- name: LEP3_ee_Afb_240GeV
+  order: LO
+- name: LEP3_ee_240GeV
+  order: LO
+- name: LEP3_mumu_Afb_240GeV
+  order: LO
+- name: LEP3_sigmaHad_240GeV
+  order: LO
+- name: LEP3_tautau_Afb_240GeV
+  order: LO
+- name: LEP3_ww_240GeV
+  order: LO
+- name: LEP3_zh_240GeV
+  order: NLO_EW
+- name: LEP3_zh_WW_240GeV
+  order: NLO_EW
+- name: LEP3_zh_ZZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aa_240GeV
+  order: NLO_EW
+- name: LEP3_zh_mumu_240GeV
+  order: NLO_EW
+- name: LEP3_zh_tautau_240GeV
+  order: NLO_EW
+- name: LEP3_ww_161GeV
+  order: LO
+- name: LEP3_161_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_161_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Wwidth
+  order: LO
+- name: LEP3_Zdata
+  order: LO
+- name: LEP3_alphaEW
   order: LO
 external_chi2:
   OptimalWW161:

--- a/sample_cards/Granada_collection/Mass_scans/out_UV_MasScan_dict_Coll_Granada_Mod_Varphi_Mass_1_1Loop.yaml
+++ b/sample_cards/Granada_collection/Mass_scans/out_UV_MasScan_dict_Coll_Granada_Mod_Varphi_Mass_1_1Loop.yaml
@@ -58,7 +58,7 @@ cll1221 : [{m: [-4.794778662810249e-6,-2]}]
 cll1111 : [{m: [-2.61422780651428e-6,-2]}]
 cbp : [{m: [0.00022765148598325797,-2]}]
 ctp : [{m: [-0.9970325672122538,-2]}]
-ctG : [{m: [0.0019121280895770068,-2]}]
+ctG : [{m: [0.0015709238991520643,-2]}]
 ccp : [{m: [0.,0]}]
 ctap : [{m: [0.00006469384887486835,-2]}]
 cmup : [{m: [0.,0]}]
@@ -111,4 +111,4 @@ cQl33 : [{m: [0.00003269799260878696,-2]}]
 # ~~~~~~~~~~~~~~~~~~~~~~
 # Miscellaneous information
 # Matching results address: /home/alejorossia/match2fit//sample_results/MatchingResult_Varphi_oneloop.dat
-# Export date: Tue 30 Sep 2025 07:59:08
+# Export date: Fri 13 Feb 2026 08:41:31

--- a/sample_cards/Granada_collection/UV_scans/SMEFiT_runcard_Granada_Mod_Varphi_Mass_1_1Loop.yaml
+++ b/sample_cards/Granada_collection/UV_scans/SMEFiT_runcard_Granada_Mod_Varphi_Mass_1_1Loop.yaml
@@ -466,7 +466,7 @@ coefficients:
   OtG:
     constrain:
     - lamVarphi:
-      - 0.0019121280895770068
+      - 0.0015709238991520643
       - 0
       yVarphiuf33:
       - 1
@@ -972,6 +972,8 @@ datasets:
   order: NLO_QCD
 - name: ATLAS_tttt_13TeV_slep_inc
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj
+  order: LO
 - name: ATLAS_SSinc_RunII_proj
   order: NLO_QCD
 - name: ATLAS_STXS_runII_13TeV_uncor_proj
@@ -1028,8 +1030,6 @@ datasets:
   order: NLO_QCD
 - name: CMS_tW_13TeV_slep_inc_proj
   order: NLO_QCD
-- name: CMS_tZ_13TeV_2016_inc_proj
-  order: NLO_QCD
 - name: CMS_tZ_13TeV_pTt_uncor_proj
   order: NLO_QCD
 - name: CMS_t_tch_13TeV_2019_diff_Yt_proj
@@ -1068,6 +1068,12 @@ datasets:
   order: NLO_QCD
 - name: HLLHC_tt_13TeV_asy
   order: NLO_QCD
+- name: ATLAS_Zjj_13TeV_dphijj_proj
+  order: LO
+- name: HLLHC_H_14TeV_Snowmass
+  order: LO
+- name: HLLHC_H_14TeV_2025
+  order: LO
 - name: CEPC_161_ww_leptonic_optim_obs
   order: LO
 - name: CEPC_161_ww_semilep_optim_obs
@@ -1123,6 +1129,8 @@ datasets:
 - name: CEPC_zh_gg_240GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_240GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_240GeV
   order: NLO_EW
 - name: CEPC_365_tt_optim_obs
   order: LO
@@ -1183,6 +1191,8 @@ datasets:
 - name: CEPC_zh_gg_365GeV
   order: NLO_EW
 - name: CEPC_zh_tautau_365GeV
+  order: NLO_EW
+- name: CEPC_zh_mumu_365GeV
   order: NLO_EW
 - name: CEPC_Wwidth
   order: LO
@@ -1276,8 +1286,6 @@ datasets:
   order: LO
 - name: FCCee_161_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_161GeV
-  order: LO
 - name: FCCee_ww_161GeV
   order: LO
 - name: FCCee_240_H_HADR
@@ -1286,7 +1294,7 @@ datasets:
   order: LO
 - name: FCCee_240_ww_semilep_optim_obs
   order: LO
-- name: FCCee_Brw_240GeV
+- name: FCCee_Brw
   order: LO
 - name: FCCee_Rb_240GeV
   order: LO
@@ -1302,15 +1310,13 @@ datasets:
   order: LO
 - name: FCCee_ee_Afb_240GeV
   order: LO
+- name: FCCee_ee_240GeV
+  order: LO
 - name: FCCee_mumu_Afb_240GeV
   order: LO
 - name: FCCee_sigmaHad_240GeV
   order: LO
 - name: FCCee_tautau_Afb_240GeV
-  order: LO
-- name: FCCee_vvh_240GeV
-  order: LO
-- name: FCCee_vvh_bb_240GeV
   order: LO
 - name: FCCee_ww_240GeV
   order: LO
@@ -1324,13 +1330,9 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_aa_240GeV
   order: NLO_EW
-- name: FCCee_zh_bb_240GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_240GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_240GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_240GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_240GeV
   order: NLO_EW
 - name: FCCee_365_H_HADR
   order: NLO_EW_only_for_ZH
@@ -1339,8 +1341,6 @@ datasets:
 - name: FCCee_365_ww_leptonic_optim_obs
   order: LO
 - name: FCCee_365_ww_semilep_optim_obs
-  order: LO
-- name: FCCee_Brw_365GeV
   order: LO
 - name: FCCee_Rb_365GeV
   order: LO
@@ -1354,27 +1354,23 @@ datasets:
   order: LO
 - name: FCCee_cc_Afb_365GeV
   order: LO
+- name: FCCee_mumu_Afb_365GeV
+  order: LO
 - name: FCCee_ee_Afb_365GeV
   order: LO
-- name: FCCee_mumu_Afb_365GeV
+- name: FCCee_ee_365GeV
   order: LO
 - name: FCCee_sigmaHad_365GeV
   order: LO
 - name: FCCee_tautau_Afb_365GeV
   order: LO
-- name: FCCee_vvh_365GeV
-  order: LO
 - name: FCCee_vvh_WW_365GeV
   order: LO
 - name: FCCee_vvh_ZZ_365GeV
   order: LO
+- name: FCCee_vvh_aZ_365GeV
+  order: LO
 - name: FCCee_vvh_aa_365GeV
-  order: LO
-- name: FCCee_vvh_bb_365GeV
-  order: LO
-- name: FCCee_vvh_cc_365GeV
-  order: LO
-- name: FCCee_vvh_gg_365GeV
   order: LO
 - name: FCCee_vvh_tautau_365GeV
   order: LO
@@ -1386,21 +1382,375 @@ datasets:
   order: NLO_EW
 - name: FCCee_zh_ZZ_365GeV
   order: NLO_EW
+- name: FCCee_zh_aZ_365GeV
+  order: NLO_EW
 - name: FCCee_zh_aa_365GeV
   order: NLO_EW
-- name: FCCee_zh_bb_365GeV
-  order: NLO_EW
-- name: FCCee_zh_cc_365GeV
-  order: NLO_EW
-- name: FCCee_zh_gg_365GeV
-  order: NLO_EW
 - name: FCCee_zh_tautau_365GeV
+  order: NLO_EW
+- name: FCCee_zh_mumu_365GeV
   order: NLO_EW
 - name: FCCee_Wwidth
   order: LO
 - name: FCCee_Zdata
   order: LO
 - name: FCCee_alphaEW
+  order: LO
+- name: LCF_Zdata_GigaZ
+  order: LO
+- name: LCF_alphaEW_250GeV
+  order: LO
+- name: LCF_vvh_bb_250GeV
+  order: LO
+- name: LCF_zh_250GeV
+  order: NLO_EW
+- name: LCF_bb_250GeV
+  order: LO
+- name: LCF_ww_250GeV
+  order: LO
+- name: LCF_zh_aa_250GeV
+  order: NLO_EW
+- name: LCF_bb_Afb_250GeV
+  order: LO
+- name: LCF_Wwidth_250GeV
+  order: LO
+- name: LCF_zh_aZ_250GeV
+  order: NLO_EW
+- name: LCF_Brw_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_bb_250GeV
+  order: NLO_EW
+- name: LCF_cc_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_cc_250GeV
+  order: NLO_EW
+- name: LCF_cc_Afb_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_gg_250GeV
+  order: NLO_EW
+- name: LCF_ee_250GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_zh_mumu_250GeV
+  order: NLO_EW
+- name: LCF_ee_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_neg30
+  order: LO
+- name: LCF_zh_tautau_250GeV
+  order: NLO_EW
+- name: LCF_mumu_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_neg80_pos30
+  order: LO
+- name: LCF_zh_ww_250GeV
+  order: NLO_EW
+- name: LCF_mumu_Afb_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_neg30
+  order: LO
+- name: LCF_zh_zz_250GeV
+  order: NLO_EW
+- name: LCF_tautau_250GeV
+  order: LO
+- name: LCF_ww_semilep_optim_obs_250GeV_pos80_pos30
+  order: LO
+- name: LCF_tautau_Afb_250GeV
+  order: LO
+- name: LCF_Zdata_250GeV
+  order: LO
+- name: LCF_Brw_350GeV
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_350GeV_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_350GeV
+  order: LO
+- name: LCF_vvh_bb_350GeV
+  order: LO
+- name: LCF_vvh_cc_350GeV
+  order: LO
+- name: LCF_vvh_gg_350GeV
+  order: LO
+- name: LCF_vvh_mumu_350GeV
+  order: LO
+- name: LCF_vvh_tautau_350GeV
+  order: LO
+- name: LCF_vvh_ww_350GeV
+  order: LO
+- name: LCF_vvh_zz_350GeV
+  order: LO
+- name: LCF_ww_350GeV
+  order: LO
+- name: LCF_zh_350GeV
+  order: NLO_EW
+- name: LCF_zh_aa_350GeV
+  order: NLO_EW
+- name: LCF_zh_bb_350GeV
+  order: NLO_EW
+- name: LCF_zh_cc_350GeV
+  order: NLO_EW
+- name: LCF_zh_gg_350GeV
+  order: NLO_EW
+- name: LCF_zh_mumu_350GeV
+  order: NLO_EW
+- name: LCF_zh_tautau_350GeV
+  order: NLO_EW
+- name: LCF_zh_ww_350GeV
+  order: NLO_EW
+- name: LCF_zh_zz_350GeV
+  order: NLO_EW
+- name: LCF_bb_500GeV_4ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_4ab
+  order: LO
+- name: LCF_Brw_500GeV_4ab
+  order: LO
+- name: LCF_cc_500GeV_4ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_4ab
+  order: LO
+- name: LCF_ee_500GeV_4ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_4ab
+  order: LO
+- name: LCF_mumu_500GeV_4ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tautau_500GeV_4ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_4ab
+  order: LO
+- name: LCF_tth_500GeV_4ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_4ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_4ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_4ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_4ab
+  order: LO
+- name: LCF_vvhh_500GeV_4ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_4ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_4ab
+  order: LO
+- name: LCF_ww_500GeV_4ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_4ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_4ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_4ab
+  order: LO
+- name: LCF_zh_tautau_500GeV_4ab
+  order: LO
+- name: LCF_zh_ww_500GeV_4ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_4ab
+  order: NLO_EW
+- name: LCF_bb_500GeV_8ab
+  order: LO
+- name: LCF_bb_Afb_500GeV_8ab
+  order: LO
+- name: LCF_Brw_500GeV_8ab
+  order: LO
+- name: LCF_cc_500GeV_8ab
+  order: LO
+- name: LCF_cc_Afb_500GeV_8ab
+  order: LO
+- name: LCF_ee_500GeV_8ab
+  order: LO
+- name: LCF_ee_Afb_500GeV_8ab
+  order: LO
+- name: LCF_mumu_500GeV_8ab
+  order: LO
+- name: LCF_mumu_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tautau_500GeV_8ab
+  order: LO
+- name: LCF_tautau_Afb_500GeV_8ab
+  order: LO
+- name: LCF_tth_500GeV_8ab
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_tt_wbwb_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_vvh_aa_500GeV_8ab
+  order: LO
+- name: LCF_vvh_bb_500GeV_8ab
+  order: LO
+- name: LCF_vvh_cc_500GeV_8ab
+  order: LO
+- name: LCF_vvh_gg_500GeV_8ab
+  order: LO
+- name: LCF_vvhh_500GeV_8ab
+  order: LO
+- name: LCF_vvh_mumu_500GeV_8ab
+  order: LO
+- name: LCF_vvh_tautau_500GeV_8ab
+  order: LO
+- name: LCF_vvh_ww_500GeV_8ab
+  order: LO
+- name: LCF_vvh_zz_500GeV_8ab
+  order: LO
+- name: LCF_ww_500GeV_8ab
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_neg80_pos30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_neg30
+  order: LO
+- name: LCF_ww_semilep_optim_obs_500GeV_8ab_pos80_pos30
+  order: LO
+- name: LCF_zh_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_aa_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_bb_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_cc_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_gg_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zhh_500GeV_8ab
+  order: LO
+- name: LCF_zh_mumu_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_tautau_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_ww_500GeV_8ab
+  order: NLO_EW
+- name: LCF_zh_zz_500GeV_8ab
+  order: NLO_EW
+- name: LCF_bb_1000GeV
+  order: LO
+- name: LCF_bb_Afb_1000GeV
+  order: LO
+- name: LCF_cc_1000GeV
+  order: LO
+- name: LCF_cc_Afb_1000GeV
+  order: LO
+- name: LCF_ee_1000GeV
+  order: LO
+- name: LCF_ee_Afb_1000GeV
+  order: LO
+- name: LCF_mumu_1000GeV
+  order: LO
+- name: LCF_mumu_Afb_1000GeV
+  order: LO
+- name: LCF_tautau_1000GeV
+  order: LO
+- name: LCF_tautau_Afb_1000GeV
+  order: LO
+- name: LCF_tth_1000GeV
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_tt_wbwb_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_vvh_aa_1000GeV
+  order: LO
+- name: LCF_vvh_bb_1000GeV
+  order: LO
+- name: LCF_vvh_cc_1000GeV
+  order: LO
+- name: LCF_vvh_gg_1000GeV
+  order: LO
+- name: LCF_vvhh_1000GeV
+  order: LO
+- name: LCF_vvh_mumu_1000GeV
+  order: LO
+- name: LCF_vvh_tautau_1000GeV
+  order: LO
+- name: LCF_vvh_ww_1000GeV
+  order: LO
+- name: LCF_vvh_zz_1000GeV
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_leptonic_optim_obs_1000GeV_pos80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_neg80_pos20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_neg20
+  order: LO
+- name: LCF_ww_semilep_optim_obs_1000GeV_pos80_pos20
   order: LO
 - name: LEP1_EWPOs_2006
   order: LO
@@ -1417,6 +1767,64 @@ datasets:
 - name: LEP_eeWW_198GeV
   order: LO
 - name: LEP_eeWW_206GeV
+  order: LO
+- name: LEP3_240_H_HADR
+  order: NLO_EW_only_for_ZH
+- name: LEP3_240_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_240_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Brw
+  order: LO
+- name: LEP3_Rb_240GeV
+  order: LO
+- name: LEP3_Rc_240GeV
+  order: LO
+- name: LEP3_Rmu_240GeV
+  order: LO
+- name: LEP3_Rtau_240GeV
+  order: LO
+- name: LEP3_bb_Afb_240GeV
+  order: LO
+- name: LEP3_cc_Afb_240GeV
+  order: LO
+- name: LEP3_ee_Afb_240GeV
+  order: LO
+- name: LEP3_ee_240GeV
+  order: LO
+- name: LEP3_mumu_Afb_240GeV
+  order: LO
+- name: LEP3_sigmaHad_240GeV
+  order: LO
+- name: LEP3_tautau_Afb_240GeV
+  order: LO
+- name: LEP3_ww_240GeV
+  order: LO
+- name: LEP3_zh_240GeV
+  order: NLO_EW
+- name: LEP3_zh_WW_240GeV
+  order: NLO_EW
+- name: LEP3_zh_ZZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aZ_240GeV
+  order: NLO_EW
+- name: LEP3_zh_aa_240GeV
+  order: NLO_EW
+- name: LEP3_zh_mumu_240GeV
+  order: NLO_EW
+- name: LEP3_zh_tautau_240GeV
+  order: NLO_EW
+- name: LEP3_ww_161GeV
+  order: LO
+- name: LEP3_161_ww_leptonic_optim_obs
+  order: LO
+- name: LEP3_161_ww_semilep_optim_obs
+  order: LO
+- name: LEP3_Wwidth
+  order: LO
+- name: LEP3_Zdata
+  order: LO
+- name: LEP3_alphaEW
   order: LO
 external_chi2:
   OptimalWW161:


### PR DESCRIPTION
Added the 1/gS factor that I had missed in the definition of $c_{tG}$. Impact in fits and numerical result restricted to 1-loop matched models and expected to be numerical small since $g_S \simeq 1$.
Before merging:

- [x] Check it works fine
- [x] Reprint matching relations in 1-loop matched models.