### PR TITLE
Fixed bug of having always read T1 model

### DIFF
--- a/match2fit.wl
+++ b/match2fit.wl
@@ -1676,7 +1676,7 @@ Options[modelToUVscanCard]={"UVFlavourAssumption"->{},"Collection"->"UserCollect
 modelToUVscanCard[directory_,model_,mass_,looplevel_,OptionsPattern[]]:=Block[{direct},
 matcher[directory,model,looplevel,"QGRAFPath"->OptionValue["QGRAFPath"]];
 If[Characters[directory][[-1]]!="/",direct=directory<>"/",direct=directory];
-dictPrinterUVcoup[direct<>model<>"_MM/MatchingResult.dat",mass,looplevel,parametersList[directory,"T1"],OptionValue["UVFlavourAssumption"],OptionValue["Collection"],model,ToString[Not[DuplicateFreeQ[Flatten[{mass}]]]],OptionValue["OutputFormat"]];]
+dictPrinterUVcoup[direct<>model<>"_MM/MatchingResult.dat",mass,looplevel,parametersList[directory,model],OptionValue["UVFlavourAssumption"],OptionValue["Collection"],model,ToString[Not[DuplicateFreeQ[Flatten[{mass}]]]],OptionValue["OutputFormat"]];]
 
 
 Options[modelToMasScanCard]={"UVFlavourAssumption"->{},"Collection"->"UserCollection","OutputFormat"->"Universal","DegenerateMasses"->"True","QGRAFPath"->""};


### PR DESCRIPTION
The function `modelToUVscanCard` had a bug via which it always read the parameter list of the T1 model instead of the one specified via the arguments. Issue #20. Fixed in this PR.